### PR TITLE
Feature: Add ratio precision helpers

### DIFF
--- a/javascript/modules/common/CHANGELOG.md
+++ b/javascript/modules/common/CHANGELOG.md
@@ -17,9 +17,9 @@ TEMPLATE:
 -->
 
 ## [UPCOMING] 
-### Added
-- `hexToBytes` function
-
+### Updated
+- Renaming `bufferToHexString` to `bytesToHex`
+- Renaming `hexStringToBuffer` to `hexToBytes`
 - Version bump
 
 ## 0.0.2-alpha

--- a/javascript/modules/common/README.md
+++ b/javascript/modules/common/README.md
@@ -1,106 +1,135 @@
-Aragon JS SDK Common
----
+# Aragon JS SDK Common
 
-<!--
-Congrats! You just saved yourself hours of work by bootstrapping this project with TSDX. Let’s get you oriented with what’s here and how to use it.
+@aragon/sdk-common provides general purpose components to use across the entire Aragon SDK:
+- Interfaces
+- Constants
+- Types
+- Enumerations
+- Helpers
 
-> This TSDX setup is meant for developing libraries (not apps!) that can be published to NPM. If you’re looking to build a Node app, you could use `ts-node-dev`, plain `ts-node`, or simple `tsc`.
+# Installation
 
-> If you’re new to TypeScript, checkout [this handy cheatsheet](https://devhints.io/typescript)
-
-## Commands
-
-TSDX scaffolds your new library inside `/src`.
-
-To run TSDX, use:
+Use [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/) to install
+@aragon/sdk-common.
 
 ```bash
-npm start # or yarn start
+npm install @aragon/sdk-common
+yarn add @aragon/sdk-common
 ```
 
-This builds to `/dist` and runs the project in watch mode so any edits you save inside `src` causes a rebuild to `/dist`.
+# Usage
 
-To do a one-off build, use `npm run build` or `yarn build`.
+## Constants
 
-To run tests, use `npm test` or `yarn test`.
+## Encoding
 
-## Configuration
+### Converting buffers and hex strings
 
-Code quality is set up for you with `prettier`, `husky`, and `lint-staged`. Adjust the respective fields in `package.json` accordingly.
+```ts
+import { hexStringToBuffer, bufferToHexString } from "@aragon/sdk-common";
 
-### Jest
+const buff = hexStringToBuffer("0xffffffff");
+// [255, 255, 255, 255]
 
-Jest tests are set up to run with `npm test` or `yarn test`.
+const str = bufferToHexString(new Uint8Array([100, 100, 100, 100, 100, 100]));
+// "646464646464"
 
-### Bundle Analysis
-
-[`size-limit`](https://github.com/ai/size-limit) is set up to calculate the real cost of your library with `npm run size` and visualize the bundle with `npm run analyze`.
-
-#### Setup Files
-
-This is the folder structure we set up for you:
-
-```txt
-/src
-  index.tsx       # EDIT THIS
-/test
-  blah.test.tsx   # EDIT THIS
-.gitignore
-package.json
-README.md         # EDIT THIS
-tsconfig.json
+const str0x = bufferToHexString(new Uint8Array([100, 100, 100, 100, 100, 100]), true);
+// "0x646464646464"
 ```
 
-### Rollup
+### Converting between buffers and big integers
 
-TSDX uses [Rollup](https://rollupjs.org) as a bundler and generates multiple rollup configs for various module formats and build settings. See [Optimizations](#optimizations) for details.
+```ts
+import { bigIntToBuffer, bigIntToLeBuffer } from "@aragon/sdk-common";
 
-### TypeScript
+const bi = BigInt("111122223333444455556666777788889999000011112222333344445555666677778888999900")
+const buff = bigIntToBuffer(bi);
+// Uint8Array(32) [ 245, 172, 243,  22, 170, 44,  13,  78, ..., 220 ]
 
-`tsconfig.json` is set up to interpret `dom` and `esnext` types, as well as `react` for `jsx`. Adjust according to your needs.
-
-## Continuous Integration
-
-### GitHub Actions
-
-Two actions are added by default:
-
-- `main` which installs deps w/ cache, lints, tests, and builds on all pushes against a Node and OS matrix
-- `size` which comments cost comparison of your library on every pull request using [`size-limit`](https://github.com/ai/size-limit)
-
-## Optimizations
-
-Please see the main `tsdx` [optimizations docs](https://github.com/palmerhq/tsdx#optimizations). In particular, know that you can take advantage of development-only optimizations:
-
-```js
-// ./types/index.d.ts
-declare var __DEV__: boolean;
-
-// inside your code...
-if (__DEV__) {
-  console.log('foo');
-}
+const buffLe = bigIntToLeBuffer(bi);
+// Uint8Array(32) [ 220,  67, 63, 224,  21,  50, 154, 103, ..., 245 ]
 ```
 
-You can also choose to install and use [invariant](https://github.com/palmerhq/tsdx#invariant) and [warning](https://github.com/palmerhq/tsdx#warning) functions.
+```ts
+import { bufferToBigInt, bufferLeToBigInt } from "@aragon/sdk-common";
 
-## Module Formats
+const buff = new Uint8Array([
+  245, 172, 243,  22, 170, 44,  13,  78,
+  106,  70,  70, 147, 249, 71, 137, 190,
+  155,  21, 186,  14, 206, 88,  97, 129,
+  103, 154,  50,  21, 224, 63,  67, 220
+]);
+const hex = bufferToBigInt(buff);
+// 111122223333444455556666777788889999000011112222333344445555666677778888999900n
 
-CJS, ESModules, and UMD module formats are supported.
+const buffLe = new Uint8Array([
+  220,  67, 63, 224,  21,  50, 154, 103,
+  129,  97, 88, 206,  14, 186,  21, 155,
+  190, 137, 71, 249, 147,  70,  70, 106,
+   78,  13, 44, 170,  22, 243, 172, 245
+]);
+const hex = bufferLeToBigInt(buffLe);
+// 111122223333444455556666777788889999000011112222333344445555666677778888999900n
+```
 
-The appropriate paths are configured in `package.json` and `dist/index.js` accordingly. Please report if any issues are found.
+### Percent ratios stored on-chain
 
-## Named Exports
+Encodes ratio values between 0 and 1 translated into an integer range with the given digit precision
 
-Per Palmer Group guidelines, [always use named exports.](https://github.com/palmerhq/typescript#exports) Code split inside your React app instead of your React library.
+```ts
+import { encodeRatio, decodeRatio } from "@aragon/sdk-common";
 
-## Including Styles
+let digits = 1
+encodeRatio(0.5, digits) // 5
+encodeRatio(0.53625, digits) // 5
+encodeRatio(0.57625, digits) // 6
 
-There are many ways to ship styles, including with CSS-in-JS. TSDX has no opinion on this, configure how you like.
+digits = 4
+encodeRatio(0.5, digits) // 5000
+encodeRatio(0.53625, digits) // 5362
+encodeRatio(0.57625, digits) // 5762
+```
 
-For vanilla CSS, you can include it at the root directory and add it to the `files` section in your `package.json`, so that it can be imported separately by your users and run through their bundler's loader.
+### Hex prefix guards
 
-## Publishing to NPM
+```ts
+import { strip0x, ensure0x } from "@aragon/sdk-common";
 
-We recommend using [np](https://github.com/sindresorhus/np).
--->
+strip0x("1234")
+// "1234"
+strip0x("0x1234")
+// "1234"
+
+ensure0x("1234")
+// "0x1234"
+ensure0x("0x1234")
+// "0x1234"
+```
+
+## Random
+
+```ts
+import { Random } from "@aragon/sdk-common";
+
+// Bytes
+Random.getBytes(1); // Uint8Array(1) [34]
+Random.getBytes(2); // Uint8Array(1) [63, 215]
+Random.getBytes(8); // Uint8Array(1) [2, 194, 201, 142, 26, 5, 77, 152]
+
+// Hex (32 bytes)
+Random.getHex(); // "9a6dbc9176afdb69d6fb9a76fdb917613bd971a6bd9176adf3b791d1bda19d17"
+
+// Big integer up to the given number
+Random.getBigInt(256n); // 251n
+
+Random.getFloat(); // 0.24152366327234
+
+Random.shuffle([1, 2, 3, 4]);  // [3, 1, 4, 2]
+```
+
+## Errors
+
+## Promises
+
+## Types

--- a/javascript/modules/common/README.md
+++ b/javascript/modules/common/README.md
@@ -26,15 +26,15 @@ yarn add @aragon/sdk-common
 ### Converting buffers and hex strings
 
 ```ts
-import { hexStringToBuffer, bufferToHexString } from "@aragon/sdk-common";
+import { hexToBytes, bytesToHex } from "@aragon/sdk-common";
 
-const buff = hexStringToBuffer("0xffffffff");
+const buff = hexToBytes("0xffffffff");
 // [255, 255, 255, 255]
 
-const str = bufferToHexString(new Uint8Array([100, 100, 100, 100, 100, 100]));
+const str = bytesToHex(new Uint8Array([100, 100, 100, 100, 100, 100]));
 // "646464646464"
 
-const str0x = bufferToHexString(new Uint8Array([100, 100, 100, 100, 100, 100]), true);
+const str0x = bytesToHex(new Uint8Array([100, 100, 100, 100, 100, 100]), true);
 // "0x646464646464"
 ```
 

--- a/javascript/modules/common/src/encoding.ts
+++ b/javascript/modules/common/src/encoding.ts
@@ -53,25 +53,37 @@ export function strip0x(value: string): string {
   return value.startsWith("0x") ? value.substring(2) : value;
 }
 
-export function encodeRatio(ratio: number, digits: number): bigint {
+
+/**
+ * Encodes a 0-1 ratio within the given digit precision for storage on a smart contract
+ *
+ * @export
+ * @param {number} ratio
+ * @param {number} digits
+ * @return {*}  {bigint}
+ */
+export function encodeRatio(ratio: number, digits: number): number {
   if (ratio < 0 || ratio > 1) {
     throw new Error("The ratio value should be between 0 and 1")
   }
-  if (!Number.isInteger(digits) || digits < 0) {
-    throw new Error("The digits value should be an positive integer")
+  if (!Number.isInteger(digits) || digits < 1 || digits > 15) {
+    throw new Error("The digits value should be an positive integer between 1 and 15")
   }
-  return BigInt(Math.round(ratio * (10 ** digits)))
+  return Math.round(ratio * (10 ** digits))
 }
-
+/**
+ * Decodes a value received from a smart contract to a number with
+ *
+ * @export
+ * @param {bigint} onChainValue
+ * @param {number} digits
+ * @return {*}  {number}
+ */
 export function decodeRatio(onChainValue: bigint, digits: number): number {
-  if (!Number.isInteger(digits) || digits < 0) {
-    throw new Error("The number of digits should be a positive int")
+  if (!Number.isInteger(digits) || digits < 1 || digits > 15) {
+    throw new Error("The number of digits should be a positive integer between 1 and 15")
   }
-  const s = onChainValue.toString()
-  if (digits < s.length) {
-    return parseFloat(s.substring(0, s.length - digits) + '.' + s.substring(s.length - digits, s.length))
-  }
-  return parseFloat("0." + "0".repeat(digits - s.length) + s)
+  return parseFloat(onChainValue.toString()) / (10 ** digits)
 }
 
 export function hexToBytes(hex: string): Uint8Array {

--- a/javascript/modules/common/src/encoding.ts
+++ b/javascript/modules/common/src/encoding.ts
@@ -1,16 +1,23 @@
 /** Decodes a hex string and returns it as a buffer */
-export function hexStringToBuffer(hexString: string): Buffer {
+export function hexToBytes(hexString: string): Uint8Array {
   if (!/^(0x)?[0-9a-fA-F]+$/.test(hexString)) {
     throw new Error("Invalid hex string");
   } else if (hexString.length % 2 !== 0) {
-    throw new Error("The hex string contains an odd length");
+    throw new Error("The hex string has an odd length");
   }
 
-  return Buffer.from(strip0x(hexString), "hex");
+  hexString = strip0x(hexString);
+  const bytes = [];
+  for (let i = 0; i < hexString.length; i += 2) {
+    bytes.push(
+      parseInt(hexString.substring(i, i + 2), 16),
+    );
+  }
+  return Uint8Array.from(bytes);
 }
 
 /** Encodes a buffer into a hex string */
-export function bufferToHexString(buff: Uint8Array, prepend0x?: boolean): string {
+export function bytesToHex(buff: Uint8Array, prepend0x?: boolean): string {
   const bytes: string[] = [];
   for (let i = 0; i < buff.length; i++) {
     if (buff[i] >= 16) bytes.push(buff[i].toString(16));
@@ -21,14 +28,14 @@ export function bufferToHexString(buff: Uint8Array, prepend0x?: boolean): string
 }
 
 /** Encodes the given big integer as a 32 byte big endian buffer */
-export function bigIntToBuffer(number: bigint): Buffer {
+export function bigIntToBuffer(number: bigint): Uint8Array {
   let hexNumber = number.toString(16);
   while (hexNumber.length < 64) hexNumber = "0" + hexNumber;
-  return Buffer.from(hexNumber, "hex");
+  return hexToBytes(hexNumber);
 }
 
 /** Encodes the given big integer as a 32 byte little endian buffer */
-export function bigIntToLeBuffer(number: bigint): Buffer {
+export function bigIntToLeBuffer(number: bigint): Uint8Array {
   return bigIntToBuffer(number).reverse();
 }
 
@@ -92,12 +99,4 @@ export function decodeRatio(
   }
 
   return Number(onChainValue) / (10 ** digits);
-}
-
-export function hexToBytes(hex: string): Uint8Array {
-  const hexMatch = hex.match(/.{1,2}/g)
-  if (!hexMatch) {
-    throw new Error("invalid hex string")
-  }
-  return Uint8Array.from(hexMatch.map((byte) => parseInt(byte, 16)));
 }

--- a/javascript/modules/common/src/encoding.ts
+++ b/javascript/modules/common/src/encoding.ts
@@ -10,7 +10,7 @@ export function hexStringToBuffer(hexString: string): Buffer {
 }
 
 /** Encodes a buffer into a hex string */
-export function uintArrayToHex(buff: Uint8Array, prepend0x?: boolean): string {
+export function bufferToHexString(buff: Uint8Array, prepend0x?: boolean): string {
   const bytes: string[] = [];
   for (let i = 0; i < buff.length; i++) {
     if (buff[i] >= 16) bytes.push(buff[i].toString(16));
@@ -53,7 +53,6 @@ export function strip0x(value: string): string {
   return value.startsWith("0x") ? value.substring(2) : value;
 }
 
-
 /**
  * Encodes a 0-1 ratio within the given digit precision for storage on a smart contract
  *
@@ -64,12 +63,13 @@ export function strip0x(value: string): string {
  */
 export function encodeRatio(ratio: number, digits: number): number {
   if (ratio < 0 || ratio > 1) {
-    throw new Error("The ratio value should be between 0 and 1")
+    throw new Error("The ratio value should range between 0 and 1");
+  } else if (!Number.isInteger(digits) || digits < 1 || digits > 15) {
+    throw new Error(
+      "The number of digits should range between 1 and 15",
+    );
   }
-  if (!Number.isInteger(digits) || digits < 1 || digits > 15) {
-    throw new Error("The digits value should be an positive integer between 1 and 15")
-  }
-  return Math.round(ratio * (10 ** digits))
+  return Math.round(ratio * (10 ** digits));
 }
 /**
  * Decodes a value received from a smart contract to a number with
@@ -79,11 +79,19 @@ export function encodeRatio(ratio: number, digits: number): number {
  * @param {number} digits
  * @return {*}  {number}
  */
-export function decodeRatio(onChainValue: bigint, digits: number): number {
+export function decodeRatio(
+  onChainValue: bigint | number,
+  digits: number,
+): number {
   if (!Number.isInteger(digits) || digits < 1 || digits > 15) {
-    throw new Error("The number of digits should be a positive integer between 1 and 15")
+    throw new Error(
+      "The number of digits should be a positive integer between 1 and 15",
+    );
+  } else if (onChainValue > 10 ** digits) {
+    throw new Error("The value is out of range");
   }
-  return parseFloat(onChainValue.toString()) / (10 ** digits)
+
+  return Number(onChainValue) / (10 ** digits);
 }
 
 export function hexToBytes(hex: string): Uint8Array {

--- a/javascript/modules/common/src/encoding.ts
+++ b/javascript/modules/common/src/encoding.ts
@@ -53,6 +53,27 @@ export function strip0x(value: string): string {
   return value.startsWith("0x") ? value.substring(2) : value;
 }
 
+export function encodeRatio(ratio: number, digits: number): bigint {
+  if (ratio < 0 || ratio > 1) {
+    throw new Error("The ratio value should be between 0 and 1")
+  }
+  if (!Number.isInteger(digits) || digits < 0) {
+    throw new Error("The digits value should be an positive integer")
+  }
+  return BigInt(Math.round(ratio * (10 ** digits)))
+}
+
+export function decodeRatio(onChainValue: bigint, digits: number): number {
+  if (!Number.isInteger(digits) || digits < 0) {
+    throw new Error("The number of digits should be a positive int")
+  }
+  const s = onChainValue.toString()
+  if (digits < s.length) {
+    return parseFloat(s.substring(0, s.length - digits) + '.' + s.substring(s.length - digits, s.length))
+  }
+  return parseFloat("0." + "0".repeat(digits - s.length) + s)
+}
+
 export function hexToBytes(hex: string): Uint8Array {
   const hexMatch = hex.match(/.{1,2}/g)
   if (!hexMatch) {

--- a/javascript/modules/common/src/random.ts
+++ b/javascript/modules/common/src/random.ts
@@ -1,22 +1,22 @@
-import { uintArrayToHex } from "./encoding";
+import { bufferToHexString } from "./encoding";
 
 export namespace Random {
   /**
    * Generates a random buffer of the given length
    */
-  export function getBytes(count: number): Buffer {
+  export function getBytes(count: number): Uint8Array {
     if (typeof window?.crypto?.getRandomValues == "function") {
       // Browser
       const buff = new Uint8Array(count);
       window.crypto.getRandomValues(buff);
-      return Buffer.from(buff);
+      return buff;
     } else if (
       // NodeJS
       typeof process !== "undefined" &&
       typeof require !== "undefined" &&
       typeof require("crypto")?.randomBytes !== "undefined"
     ) {
-      return require("crypto").randomBytes(count);
+      return new Uint8Array(require("crypto").randomBytes(count));
     }
 
     // other environments (fallback)
@@ -25,7 +25,7 @@ export namespace Random {
       const val = (Math.random() * 256) | 0;
       result.push(val);
     }
-    return Buffer.from(result);
+    return new Uint8Array(result);
   }
 
   /**
@@ -33,7 +33,7 @@ export namespace Random {
    */
   export function getHex(): string {
     const bytes = getBytes(32);
-    return uintArrayToHex(bytes);
+    return bufferToHexString(bytes);
   }
 
   /**

--- a/javascript/modules/common/src/random.ts
+++ b/javascript/modules/common/src/random.ts
@@ -1,4 +1,4 @@
-import { bufferToHexString } from "./encoding";
+import { bytesToHex } from "./encoding";
 
 export namespace Random {
   /**
@@ -33,7 +33,7 @@ export namespace Random {
    */
   export function getHex(): string {
     const bytes = getBytes(32);
-    return bufferToHexString(bytes);
+    return bytesToHex(bytes);
   }
 
   /**

--- a/javascript/modules/common/test/unit/encoding.test.ts
+++ b/javascript/modules/common/test/unit/encoding.test.ts
@@ -278,23 +278,25 @@ describe("Value encoding", () => {
   it("Should return a bigint encoded from a float between 1 and 0  and a positive integer number of digits", () => {
     expect(() => encodeRatio(-0.5, 4)).toThrow("The ratio value should be between 0 and 1")
     expect(() => encodeRatio(5, 4)).toThrow("The ratio value should be between 0 and 1")
-    expect(() => encodeRatio(0.5, -1)).toThrow("The digits value should be an positive integer")
+    expect(() => encodeRatio(0.5, -1)).toThrow("The digits value should be an positive integer between 1 and 15")
+    expect(() => encodeRatio(0.5, 18)).toThrow("The digits value should be an positive integer between 1 and 15")
 
     const inputs = [
       // strip
-      { in: [0.5, 1], out: "5" },
-      { in: [0.5, 4], out: "5000" },
-      { in: [0.5, 18], out: "500000000000000000" },
+      { in: [0.5, 1], out: 5 },
+      { in: [0.5, 4], out: 5000 },
+      { in: [0.5, 10], out: 5000000000 },
     ];
 
     for (let input of inputs) {
       const result = encodeRatio(input.in[0], input.in[1]);
-      expect(result.toString()).toEqual(input.out);
+      expect(result).toEqual(input.out);
     }
   });
 
   it("Should decode a float from a given bigint and positive integer number of digits", () => {
-    expect(() => encodeRatio(0.5, -1)).toThrow("The digits value should be an positive integer")
+    expect(() => encodeRatio(0.5, -1)).toThrow("The digits value should be an positive integer between 1 and 15")
+    expect(() => encodeRatio(0.5, 18)).toThrow("The digits value should be an positive integer between 1 and 15")
 
     const inputs = [
       // strip

--- a/javascript/modules/common/test/unit/encoding.test.ts
+++ b/javascript/modules/common/test/unit/encoding.test.ts
@@ -3,6 +3,8 @@ import {
   bigIntToLeBuffer,
   bufferLeToBigInt,
   bufferToBigInt,
+  decodeRatio,
+  encodeRatio,
   ensure0x,
   hexStringToBuffer,
   hexToBytes,
@@ -269,6 +271,40 @@ describe("Value encoding", () => {
 
     for (let input of inputs) {
       const result = ensure0x(input.in);
+      expect(result).toEqual(input.out);
+    }
+  });
+
+  it("Should return a bigint encoded from a float between 1 and 0  and a positive integer number of digits", () => {
+    expect(() => encodeRatio(-0.5, 4)).toThrow("The ratio value should be between 0 and 1")
+    expect(() => encodeRatio(5, 4)).toThrow("The ratio value should be between 0 and 1")
+    expect(() => encodeRatio(0.5, -1)).toThrow("The digits value should be an positive integer")
+
+    const inputs = [
+      // strip
+      { in: [0.5, 1], out: "5" },
+      { in: [0.5, 4], out: "5000" },
+      { in: [0.5, 18], out: "500000000000000000" },
+    ];
+
+    for (let input of inputs) {
+      const result = encodeRatio(input.in[0], input.in[1]);
+      expect(result.toString()).toEqual(input.out);
+    }
+  });
+
+  it("Should decode a float from a given bigint and positive integer number of digits", () => {
+    expect(() => encodeRatio(0.5, -1)).toThrow("The digits value should be an positive integer")
+
+    const inputs = [
+      // strip
+      { bigint: BigInt(5), digits: 1, out: 0.5 },
+      { bigint: BigInt(5456), digits: 4, out: 0.5456 },
+      { bigint: BigInt(512345898367483947), digits: 9, out: 512345898.367483947 }, // js loses precision above 6 digits
+    ];
+
+    for (let input of inputs) {
+      const result = decodeRatio(input.bigint, input.digits);
       expect(result).toEqual(input.out);
     }
   });

--- a/javascript/modules/common/test/unit/encoding.test.ts
+++ b/javascript/modules/common/test/unit/encoding.test.ts
@@ -3,13 +3,12 @@ import {
   bigIntToLeBuffer,
   bufferLeToBigInt,
   bufferToBigInt,
+  bytesToHex,
   decodeRatio,
   encodeRatio,
   ensure0x,
-  hexStringToBuffer,
   hexToBytes,
   strip0x,
-  bufferToHexString,
 } from "../../src";
 
 describe("Value encoding", () => {
@@ -34,7 +33,7 @@ describe("Value encoding", () => {
     ];
 
     for (let input of inputs) {
-      const result = hexStringToBuffer(input.hex);
+      const result = hexToBytes(input.hex);
       expect(result.join(",")).toEqual(input.serializedBuffer);
     }
   });
@@ -100,7 +99,7 @@ describe("Value encoding", () => {
     ];
 
     for (let item of items) {
-      const hex = bufferToHexString(item.buffer, item.with0x);
+      const hex = bytesToHex(item.buffer, item.with0x);
       expect(hex).toEqual(item.output);
     }
   });
@@ -163,10 +162,12 @@ describe("Value encoding", () => {
 
     for (let input of inputs) {
       const result = bigIntToBuffer(input.bigint);
-      expect(result.toString("hex")).toEqual(input.hexBuffer);
+      expect(Buffer.from(result).toString("hex")).toEqual(input.hexBuffer);
 
       const leResult = bigIntToLeBuffer(input.bigint);
-      expect(leResult.reverse().toString("hex")).toEqual(input.hexBuffer);
+      expect(Buffer.from(leResult).reverse().toString("hex")).toEqual(
+        input.hexBuffer,
+      );
     }
   });
 
@@ -276,10 +277,18 @@ describe("Value encoding", () => {
   });
 
   it("Should return an integer encoded from a float between 1 and 0 and a positive integer number of digits", () => {
-    expect(() => encodeRatio(-0.5, 4)).toThrow("The ratio value should range between 0 and 1")
-    expect(() => encodeRatio(5, 4)).toThrow("The ratio value should range between 0 and 1")
-    expect(() => encodeRatio(0.5, -1)).toThrow("The number of digits should range between 1 and 15")
-    expect(() => encodeRatio(0.5, 18)).toThrow("The number of digits should range between 1 and 15")
+    expect(() => encodeRatio(-0.5, 4)).toThrow(
+      "The ratio value should range between 0 and 1",
+    );
+    expect(() => encodeRatio(5, 4)).toThrow(
+      "The ratio value should range between 0 and 1",
+    );
+    expect(() => encodeRatio(0.5, -1)).toThrow(
+      "The number of digits should range between 1 and 15",
+    );
+    expect(() => encodeRatio(0.5, 18)).toThrow(
+      "The number of digits should range between 1 and 15",
+    );
 
     const inputs = [
       { in: [0.5, 1], out: 5 },
@@ -300,8 +309,12 @@ describe("Value encoding", () => {
   });
 
   it("Should decode a float from a given bigint and a number of digits", () => {
-    expect(() => encodeRatio(0.5, -1)).toThrow("The number of digits should range between 1 and 15")
-    expect(() => encodeRatio(0.5, 18)).toThrow("The number of digits should range between 1 and 15")
+    expect(() => encodeRatio(0.5, -1)).toThrow(
+      "The number of digits should range between 1 and 15",
+    );
+    expect(() => encodeRatio(0.5, 18)).toThrow(
+      "The number of digits should range between 1 and 15",
+    );
 
     const inputs = [
       { bigint: BigInt(5), digits: 1, out: 0.5 },
@@ -319,22 +332,13 @@ describe("Value encoding", () => {
       expect(result).toEqual(input.out);
     }
 
-    expect(() => decodeRatio(Number.MAX_SAFE_INTEGER + 1, 12)).toThrow("The value is out of range")
-    expect(() => decodeRatio(BigInt("512345898367483947"), 12)).toThrow("The value is out of range")
-    expect(() => decodeRatio(10 ** 2, 1)).toThrow("The value is out of range")
-    expect(() => decodeRatio(10 ** 10, 9)).toThrow("The value is out of range")
-  });
-
-  it("Should convert a hex string to a decimal Uint8Array", () => {
-    const inputs = [
-      { in: "61", out: new Uint8Array([97]) },
-      { in: "6161", out: new Uint8Array([97, 97]) },
-      { in: "616162", out: new Uint8Array([97, 97, 98]) },
-      { in: "68656c6c6f207468657265", out: new Uint8Array([104, 101, 108, 108, 111, 32, 116, 104, 101, 114, 101]) }
-    ]
-    for (let input of inputs) {
-      const result = hexToBytes(input.in);
-      expect(result.toString()).toEqual(input.out.toString());
-    }
+    expect(() => decodeRatio(Number.MAX_SAFE_INTEGER + 1, 12)).toThrow(
+      "The value is out of range",
+    );
+    expect(() => decodeRatio(BigInt("512345898367483947"), 12)).toThrow(
+      "The value is out of range",
+    );
+    expect(() => decodeRatio(10 ** 2, 1)).toThrow("The value is out of range");
+    expect(() => decodeRatio(10 ** 10, 9)).toThrow("The value is out of range");
   });
 });


### PR DESCRIPTION
## Description

Creates 2 helpers to encode a float (0-1) to a bigint and decode it back to a float. 

__This has a precision problem when the digit value is too high__ 

Task: [APP-850](https://aragonassociation.atlassian.net/browse/APP-850)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.