### PR TITLE
Fix: Workflow failing after tests pass

### DIFF
--- a/.github/workflows/javascript_test.yml
+++ b/.github/workflows/javascript_test.yml
@@ -47,8 +47,14 @@ jobs:
       - name: Build subpackages
         run: yarn run build
 
-      - name: Test
-        run: yarn test --ci --coverage
+      - name: Integration test
+        run: yarn test modules/client/test/integration --ci --coverage
+        env:
+          DAO_FACTORY: ${{ steps.contracts.outputs.dao }}
+          IPFS_API_KEY: ${{ secrets.IPFS_API_KEY }}
+
+      - name: Unit test
+        run: yarn test --testPathIgnorePatterns=modules/client/test/integration --ci --coverage
         env:
           DAO_FACTORY: ${{ steps.contracts.outputs.dao }}
           IPFS_API_KEY: ${{ secrets.IPFS_API_KEY }}


### PR DESCRIPTION
## Description

GitHub test workflow was failing with a segment violation after passing all the tests. This happened when the number of tests was too high, so the testing suites are now divided between integration and unit

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.