### PR TITLE
Fix: `getProposals` default limits

### DIFF
--- a/javascript/modules/client/package.json
+++ b/javascript/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "0.10.1-alpha",
+  "version": "0.10.2-alpha",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/javascript/modules/client/src/client-addressList.ts
+++ b/javascript/modules/client/src/client-addressList.ts
@@ -423,7 +423,7 @@ export class ClientAddressList extends ClientCore
 
   private async _getProposals({
     daoAddressOrEns,
-    limit = 0,
+    limit = 10,
     skip = 0,
     direction = SortDirection.ASC,
     sortBy = ProposalSortBy.CREATED_AT,

--- a/javascript/modules/client/src/client-erc20.ts
+++ b/javascript/modules/client/src/client-erc20.ts
@@ -541,7 +541,7 @@ export class ClientErc20 extends ClientCore implements IClientErc20 {
 
   private async _getProposals({
     daoAddressOrEns,
-    limit = 0,
+    limit = 10,
     skip = 0,
     direction = SortDirection.ASC,
     sortBy = ProposalSortBy.CREATED_AT,


### PR DESCRIPTION
## Description

`getProposals` default limits were set to 0 instead of 10, this made the sdk crash when trying to make this request

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.