### PR TITLE
fix: update workflow with new github rule

### DIFF
--- a/.github/workflows/documentation-update.yml
+++ b/.github/workflows/documentation-update.yml
@@ -16,8 +16,9 @@ jobs:
         with:
           token: ${{ secrets.ARABOT_PAT }}
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 16
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/documentation-update.yml
+++ b/.github/workflows/documentation-update.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn run docs:addressList
       - name: Get short commit hash
         id: hash
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Commit updated docs
         id: commit
         run: |

--- a/.github/workflows/javascript_publish.yml
+++ b/.github/workflows/javascript_publish.yml
@@ -21,8 +21,8 @@ jobs:
           VERSION=$(echo "$TAG" | grep -woP "([0-9]+\.[0-9]+\.[0-9]+)-\w+" | sed 's/-javascript//')
           PACKAGE=$(echo "$TAG" | grep -oP "javascript-(.+)" | sed 's/javascript-//')
           if [ -d "./modules/$PACKAGE" ]; then
-            echo "::set-output name=package::$PACKAGE"
-            echo "::set-output name=version::$VERSION"
+            echo "package=$PACKAGE" >> $GITHUB_OUTPUT
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
           fi
   test:
     uses: ./.github/workflows/javascript_test.yml

--- a/.github/workflows/javascript_publish.yml
+++ b/.github/workflows/javascript_publish.yml
@@ -49,8 +49,9 @@ jobs:
         with:
           token: ${{ secrets.ARABOT_PAT }}
       - name: Install node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: 16
           registry-url: "https://registry.npmjs.org"
 

--- a/.github/workflows/javascript_release.yml
+++ b/.github/workflows/javascript_release.yml
@@ -47,7 +47,7 @@ jobs:
         id: version
         run: | 
           VERSION=$(cat package.json | jq -r .version)
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
         working-directory: './modules/${{ matrix.package }}'
       - name: create tag
         uses: actions/github-script@v5

--- a/.github/workflows/javascript_test.yml
+++ b/.github/workflows/javascript_test.yml
@@ -30,8 +30,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
+          cache: "yarn"
           node-version: ${{ matrix.node }}
  
       - name: install deps


### PR DESCRIPTION
## Description

Github changed the rule on how to set outputs in workflows. (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Task: DOPS-386
