### PR TITLE
Fix: Removed toUtf8String

### DIFF
--- a/modules/client/src/internal/client/methods.ts
+++ b/modules/client/src/internal/client/methods.ts
@@ -62,7 +62,7 @@ import {
   unwrapDepositParams,
 } from "../utils";
 import { isAddress } from "@ethersproject/address";
-import { toUtf8Bytes, toUtf8String } from "@ethersproject/strings";
+import { toUtf8Bytes } from "@ethersproject/strings";
 import { id } from "@ethersproject/hash";
 
 /**
@@ -105,7 +105,7 @@ export class ClientMethods extends ClientCore implements IClientMethods {
       pluginInstallationData.push({
         pluginSetup: latestVersion[1],
         pluginSetupRepo: plugin.id,
-        data: toUtf8String(plugin.data),
+        data: plugin.data,
       });
     }
 


### PR DESCRIPTION
## Description

toUtf8String in createDAO method is causing an invalid codepoint error when the argument passes is already a string value

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.