### PR TITLE
Fix: BigInt overflow in deposit

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -17,6 +17,8 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+### Fixed
+- Bigint overflow in deposit
 
 ## 0.15.0-alpha
 On 2022-11-26 10:27:25

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "0.15.0-alpha",
+  "version": "0.15.1-alpha",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/src/internal/client/methods.ts
+++ b/modules/client/src/internal/client/methods.ts
@@ -178,7 +178,7 @@ export class ClientMethods extends ClientCore implements IClientMethods {
       // Relay the yield steps to the caller as they are received
       yield* this.ensureAllowance(
         daoAddress,
-        amount.toBigInt(),
+        params.amount,
         tokenAddress,
         signer,
       );
@@ -267,8 +267,8 @@ export class ClientMethods extends ClientCore implements IClientMethods {
       if (!log) {
         throw new Error("Could not find the Approval event");
       }
-      const value = parseInt(log.data);
-      if (!value || BigNumber.from(amount).gt(value)) {
+      const value = log.data
+      if (!value || BigNumber.from(amount).gt(BigNumber.from(value))) {
         throw new Error("Could not update allowance");
       }
     });

--- a/modules/client/test/integration/client/methods.test.ts
+++ b/modules/client/test/integration/client/methods.test.ts
@@ -158,10 +158,10 @@ describe("Client", () => {
         const client = new Client(context);
 
         const tokenContract = await deployErc20(client);
-
+        const amount = BigInt("1000000000000000000")
         const depositParams: IDepositParams = {
           daoAddressOrEns: daoAddress,
-          amount: BigInt(5),
+          amount,
           tokenAddress: tokenContract.address,
           reference: "My reference",
         };
@@ -186,7 +186,7 @@ describe("Client", () => {
               break;
             case DaoDepositSteps.UPDATED_ALLOWANCE:
               expect(typeof step.allowance).toBe("bigint");
-              expect(step.allowance).toBe(BigInt(5));
+              expect(step.allowance).toBe(amount);
               break;
             case DaoDepositSteps.DEPOSITING:
               expect(typeof step.txHash).toBe("string");
@@ -194,7 +194,7 @@ describe("Client", () => {
               break;
             case DaoDepositSteps.DONE:
               expect(typeof step.amount).toBe("bigint");
-              expect(step.amount).toBe(BigInt(5));
+              expect(step.amount).toBe(amount);
               break;
             default:
               throw new Error(
@@ -209,7 +209,7 @@ describe("Client", () => {
               depositParams.daoAddressOrEns,
             )
           ).toString(),
-        ).toBe("5");
+        ).toBe(amount.toString());
       });
 
       it("Should allow to deposit ERC20 (with existing allowance)", async () => {


### PR DESCRIPTION
## Description

In the deposit, if you pass a big enough number to the deposit, it will crash due to a `parseInt` in the `ensureAllowance` method 

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.