### PR TITLE
Fix: Resolve IPFS cid cross-browser compatibility

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -19,6 +19,7 @@ TEMPLATE:
 ## [UPCOMING]
 ### Fixed
 - Reading metadata back now parses the IPFS URI schema
+- Fix `resolveIpfsCid()` cross-browser compatibility
 
 ### Changed
 - Removed `tokenAddresses` param from `getBalances()` function

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "0.15.2-alpha",
+  "version": "0.15.3-alpha",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@aragon/core-contracts-ethers": "^0.4.1-alpha",
-    "@aragon/sdk-common": "^0.8.0-alpha",
+    "@aragon/sdk-common": "^0.8.1-alpha",
     "@aragon/sdk-ipfs": "^0.2.0-alpha",
     "@ethersproject/abstract-signer": "^5.5.0",
     "@ethersproject/bignumber": "^5.6.0",

--- a/modules/common/CHANGELOG.md
+++ b/modules/common/CHANGELOG.md
@@ -17,6 +17,9 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+### Fixed
+- Fix helper function to resolve IPFS CIDS
+## [0.8.0-alpha]
 ### Added
 - Helper function to resolve IPFS CID's
 

--- a/modules/common/package.json
+++ b/modules/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-common",
   "author": "Aragon Association",
-  "version": "0.8.0-alpha",
+  "version": "0.8.1-alpha",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-common.esm.js",
@@ -53,5 +53,8 @@
     "tsdx": "^0.14.1",
     "tslib": "^2.3.1",
     "typescript": "^4.6.2"
+  },
+  "dependencies": {
+    "parse-url": "^8.1.0"
   }
 }

--- a/modules/common/src/uri.ts
+++ b/modules/common/src/uri.ts
@@ -15,9 +15,9 @@ export function resolveIpfsCid(data: string): string {
     return data;
   }
 
-  const metadataUri = new URL(data);
-  if (!IPFS_CID_REGEX.test(metadataUri.host)) {
+  const metadataCid = data.split(PROTOCOL_REGEX)[1];
+  if (!IPFS_CID_REGEX.test(metadataCid)) {
     throw new InvalidCidError();
   }
-  return metadataUri.host;
+  return metadataCid;
 }

--- a/modules/common/src/uri.ts
+++ b/modules/common/src/uri.ts
@@ -1,3 +1,4 @@
+import parseUrl from "parse-url";
 import { InvalidCidError } from "./errors";
 
 const IPFS_CID_REGEX =
@@ -14,10 +15,9 @@ export function resolveIpfsCid(data: string): string {
     }
     return data;
   }
-
-  const metadataCid = data.split(PROTOCOL_REGEX)[1];
-  if (!IPFS_CID_REGEX.test(metadataCid)) {
+  const url = parseUrl(data);
+  if (!IPFS_CID_REGEX.test(url.resource)) {
     throw new InvalidCidError();
   }
-  return metadataCid;
+  return url.resource;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8123,6 +8123,20 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-path@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse-path/-/parse-path-7.0.0.tgz#605a2d58d0a749c8594405d8cc3a2bf76d16099b"
+  integrity sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==
+  dependencies:
+    protocols "^2.0.0"
+
+parse-url@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-8.1.0.tgz#972e0827ed4b57fc85f0ea6b0d839f0d8a57a57d"
+  integrity sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
+  dependencies:
+    parse-path "^7.0.0"
+
 parse5-htmlparser2-tree-adapter@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz#23c2cc233bcf09bb7beba8b8a69d46b08c62c2f1"
@@ -8374,6 +8388,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+protocols@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/protocols/-/protocols-2.0.1.tgz#8f155da3fc0f32644e83c5782c8e8212ccf70a86"
+  integrity sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==
 
 proxy-addr@~2.0.7:
   version "2.0.7"


### PR DESCRIPTION
## Description

The `new URL()` works differently depending on the browser (Chromium based, Firefox or Safari), to avoid this I changed the `new URL()` for a `.split(regex)` to remove the protocol from the cid string.

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.