### PR TITLE
Fix: Support for ERC721 on TokenVotingClient function getProposals

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -11,13 +11,12 @@ TEMPLATE:
 
 - Change 1, 2, 3
 
-### Fixed
-- Fix 1, 2, 3
 -->
 
 ## [UPCOMING]
 ### Fixed
 - Fix `updateMetadata` decoders
+- Fix `getProposals` ERC721 support on `tokenVotingClient`
 ### Changed
 - Add `MultisigClient`
 - Exposes `ensureAllowance` method

--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -17,6 +17,7 @@ TEMPLATE:
 ### Fixed
 - Fix `updateMetadata` decoders
 - Fix `getProposals` ERC721 support on `tokenVotingClient`
+- Fix `VotingMode` not decoding
 ### Changed
 - Add `MultisigClient`
 - Exposes `ensureAllowance` method

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "0.17.0-alpha",
+  "version": "0.17.1-alpha",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/src/client-common/encoding.ts
+++ b/modules/client/src/client-common/encoding.ts
@@ -11,7 +11,7 @@ import {
 import { VotingMode, VotingSettings } from "./interfaces/plugin";
 import { FunctionFragment, Interface, Result } from "@ethersproject/abi";
 import { BigNumber } from "@ethersproject/bignumber";
-import { parseEtherRatio, votingModeToContracts } from "./utils";
+import { parseEtherRatio, votingModeFromContracts, votingModeToContracts } from "./utils";
 import { parseEther } from "@ethersproject/units";
 
 export function decodeUpdatePluginSettingsAction(
@@ -49,10 +49,11 @@ export function encodeUpdateVotingSettingsAction(
 
 function pluginSettingsFromContract(result: Result): VotingSettings {
   return {
-    minProposerVotingPower: BigInt(result[0][0]),
+    votingMode: votingModeFromContracts(result[0][0]),
     supportThreshold: parseEtherRatio(result[0][1]),
     minParticipation: parseEtherRatio(result[0][2]),
     minDuration: result[0][3].toNumber(),
+    minProposerVotingPower: BigInt(result[0][4]),
   };
 }
 

--- a/modules/client/src/client-common/utils.ts
+++ b/modules/client/src/client-common/utils.ts
@@ -112,10 +112,22 @@ export function votingModeToContracts(votingMode: VotingMode): number {
       throw new InvalidVotingModeError();
   }
 }
+export function votingModeFromContracts(votingMode: number): VotingMode {
+  switch (votingMode) {
+    case 0:
+      return VotingMode.STANDARD;
+    case 1:
+      return VotingMode.EARLY_EXECUTION;
+    case 2:
+      return VotingMode.VOTE_REPLACEMENT;
+    default:
+      throw new InvalidVotingModeError();
+  }
+}
 
 export function parseEtherRatio(ether: string, precision: number = 2): number {
   if (precision <= 0 || !Number.isInteger(precision)) {
-    throw new InvalidPrecisionError()
+    throw new InvalidPrecisionError();
   }
   return parseFloat(
     parseFloat(

--- a/modules/client/src/tokenVoting/internal/graphql-queries/proposal.ts
+++ b/modules/client/src/tokenVoting/internal/graphql-queries/proposal.ts
@@ -73,9 +73,16 @@ query TokenVotingProposals($where: TokenVotingProposal_filter!, $limit:Int!, $sk
     executable
     plugin{
       token{
-        symbol
-        name
         id
+        name
+        symbol
+        __typename
+        ...on ERC20Token {
+          decimals
+        }
+        ...on ERC721Token {
+          baseURI
+        }
       }
     }
   }

--- a/modules/client/test/integration/client-addressList/decoding.test.ts
+++ b/modules/client/test/integration/client-addressList/decoding.test.ts
@@ -5,6 +5,7 @@ import {
   ClientAddressList,
   Context,
   ContextPlugin,
+  VotingMode,
   VotingSettings,
 } from "../../../src";
 import { contextParamsLocalChain } from "../constants";
@@ -19,7 +20,8 @@ describe("Client Address List", () => {
         minDuration: 100000,
         minParticipation: 0.25,
         supportThreshold: 0.51,
-        minProposerVotingPower: BigInt(0)
+        minProposerVotingPower: BigInt(0),
+        votingMode: VotingMode.EARLY_EXECUTION
       };
 
       const pluginAddress = "0x1234567890123456789012345678901234567890";
@@ -38,6 +40,7 @@ describe("Client Address List", () => {
       expect(decodedParams.minParticipation).toBe(params.minParticipation);
       expect(decodedParams.minProposerVotingPower).toBe(params.minProposerVotingPower);
       expect(decodedParams.supportThreshold).toBe(params.supportThreshold);
+      expect(decodedParams.votingMode).toBe(params.votingMode);
     });
 
     it("Should try to decode a invalid action and with the update plugin settings decoder return an error", async () => {

--- a/modules/client/test/integration/client-addressList/methods.test.ts
+++ b/modules/client/test/integration/client-addressList/methods.test.ts
@@ -323,7 +323,7 @@ describe("Client Address List", () => {
       const ctxPlugin = ContextPlugin.fromContext(ctx);
       const client = new ClientAddressList(ctxPlugin);
       const limit = 5;
-      const status = ProposalStatus.EXECUTED;
+      const status = ProposalStatus.DEFEATED;
       const params: IProposalQueryParams = {
         limit,
         sortBy: ProposalSortBy.CREATED_AT,

--- a/modules/client/test/integration/multisig-client/methods.test.ts
+++ b/modules/client/test/integration/multisig-client/methods.test.ts
@@ -20,7 +20,6 @@ import {
   ProposalCreationSteps,
   ProposalMetadata,
   ProposalSortBy,
-  ProposalStatus,
   SortDirection,
 } from "../../../src";
 import { GraphQLError, InvalidAddressOrEnsError } from "@aragon/sdk-common";
@@ -311,12 +310,10 @@ describe("Client Multisig", () => {
       const ctxPlugin = ContextPlugin.fromContext(ctx);
       const client = new MultisigClient(ctxPlugin);
       const limit = 5;
-      const status = ProposalStatus.EXECUTED;
       const params: IProposalQueryParams = {
         limit,
         sortBy: ProposalSortBy.CREATED_AT,
         direction: SortDirection.ASC,
-        status,
       };
       const proposals = await client.methods.getProposals(params);
 
@@ -332,7 +329,6 @@ describe("Client Multisig", () => {
         expect(proposal.creatorAddress).toMatch(/^0x[A-Fa-f0-9]{40}$/i);
         expect(typeof proposal.metadata.title).toBe("string");
         expect(typeof proposal.metadata.summary).toBe("string");
-        expect(proposal.status).toBe(status);
       }
     });
     it("Should get a list of proposals from a specific dao", async () => {

--- a/modules/client/test/integration/tokenVoting-client/decoding.test.ts
+++ b/modules/client/test/integration/tokenVoting-client/decoding.test.ts
@@ -7,6 +7,7 @@ import {
   ContextPlugin,
   IMintTokenParams,
   VotingSettings,
+  VotingMode,
 } from "../../../src";
 
 import { bytesToHex } from "@aragon/sdk-common";
@@ -22,7 +23,8 @@ describe("Token Voting Client", () => {
         minDuration: 100000,
         minParticipation: 0.25,
         supportThreshold: 0.51,
-        minProposerVotingPower: BigInt(0)
+        minProposerVotingPower: BigInt(0),
+        votingMode: VotingMode.EARLY_EXECUTION
       };
 
       const pluginAddress = "0x1234567890123456789012345678901234567890";
@@ -41,6 +43,7 @@ describe("Token Voting Client", () => {
       expect(decodedParams.minParticipation).toBe(params.minParticipation);
       expect(decodedParams.minProposerVotingPower).toBe(params.minProposerVotingPower);
       expect(decodedParams.supportThreshold).toBe(params.supportThreshold);
+      expect(decodedParams.votingMode).toBe(params.votingMode);
     });
     it("Should decode a mint action", async () => {
       const ctx = new Context(contextParamsLocalChain);

--- a/modules/client/test/integration/tokenVoting-client/methods.test.ts
+++ b/modules/client/test/integration/tokenVoting-client/methods.test.ts
@@ -353,7 +353,6 @@ describe("Token Voting Client", () => {
           limit,
           sortBy: ProposalSortBy.CREATED_AT,
           direction: SortDirection.ASC,
-          status,
         };
 
         const defaultCatImplementation = mockedIPFSClient.cat

--- a/modules/client/test/integration/tokenVoting-client/methods.test.ts
+++ b/modules/client/test/integration/tokenVoting-client/methods.test.ts
@@ -348,11 +348,12 @@ describe("Token Voting Client", () => {
         const ctxPlugin = ContextPlugin.fromContext(ctx);
         const client = new TokenVotingClient(ctxPlugin);
         const limit = 5;
-        const status = ProposalStatus.EXECUTED;
+        const status = ProposalStatus.DEFEATED;
         const params: IProposalQueryParams = {
           limit,
           sortBy: ProposalSortBy.CREATED_AT,
           direction: SortDirection.ASC,
+          status,
         };
 
         const defaultCatImplementation = mockedIPFSClient.cat


### PR DESCRIPTION
## Description

The graphql query didnt suport ERC721 which caused the request to return null on the token field

Task: [ID]()

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.