### PR TITLE
Feature: Encode ratios with 6 digit precision

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -19,6 +19,7 @@ TEMPLATE:
 ### Fixed
 - Fix `updateMetadata` decoders
 ### Changed
+- Encode ratios with 6 digits precision
 - Add `MultisigClient`
 - Exposes `ensureAllowance` method
 - Fix precission in `VotingSettings`

--- a/modules/client/src/addressList/internal/client/methods.ts
+++ b/modules/client/src/addressList/internal/client/methods.ts
@@ -1,4 +1,5 @@
 import {
+  decodeRatio,
   GraphQLError,
   InvalidAddressError,
   InvalidAddressOrEnsError,
@@ -22,7 +23,6 @@ import {
   ClientCore,
   computeProposalStatusFilter,
   ContextPlugin,
-  parseEtherRatio,
   ExecuteProposalStep,
   ExecuteProposalStepValue,
   findLog,
@@ -435,11 +435,13 @@ export class ClientAddressListMethods extends ClientCore
       }
       return {
         minDuration: parseInt(addresslistVotingPlugin.minDuration),
-        supportThreshold: parseEtherRatio(
-          addresslistVotingPlugin.supportThreshold,
+        supportThreshold: decodeRatio(
+          BigInt(addresslistVotingPlugin.supportThreshold),
+          6,
         ),
-        minParticipation: parseEtherRatio(
-          addresslistVotingPlugin.minParticipation,
+        minParticipation: decodeRatio(
+          BigInt(addresslistVotingPlugin.minParticipation),
+          6,
         ),
         minProposerVotingPower: BigInt(
           addresslistVotingPlugin.minParticipation,

--- a/modules/client/src/addressList/internal/utils.ts
+++ b/modules/client/src/addressList/internal/utils.ts
@@ -1,9 +1,8 @@
-import { hexToBytes, strip0x } from "@aragon/sdk-common";
+import { decodeRatio, hexToBytes, strip0x } from "@aragon/sdk-common";
 import {
   computeProposalStatus,
   ContractVotingSettings,
   DaoAction,
-  parseEtherRatio,
   ProposalMetadata,
   SubgraphAction,
   SubgraphVoteValuesMap,
@@ -84,8 +83,8 @@ export function toAddressListProposal(
       //   BigInt(proposal.relativeSupportThresholdPct),
       //   2,
       // ),
-      minSupport: parseEtherRatio(proposal.supportThreshold),
-      minTurnout: parseEtherRatio(proposal.minParticipation),
+      minSupport: decodeRatio(BigInt(proposal.supportThreshold), 6),
+      minTurnout: decodeRatio(BigInt(proposal.minParticipation), 6),
       duration: parseInt(proposal.endDate) -
         parseInt(proposal.startDate),
     },

--- a/modules/client/src/client-common/encoding.ts
+++ b/modules/client/src/client-common/encoding.ts
@@ -4,6 +4,8 @@ import {
 } from "@aragon/core-contracts-ethers";
 import {
   bytesToHex,
+  decodeRatio,
+  encodeRatio,
   hexToBytes,
   strip0x,
   UnexpectedActionError,
@@ -11,8 +13,7 @@ import {
 import { VotingMode, VotingSettings } from "./interfaces/plugin";
 import { FunctionFragment, Interface, Result } from "@ethersproject/abi";
 import { BigNumber } from "@ethersproject/bignumber";
-import { parseEtherRatio, votingModeToContracts } from "./utils";
-import { parseEther } from "@ethersproject/units";
+import { votingModeToContracts } from "./utils";
 
 export function decodeUpdatePluginSettingsAction(
   data: Uint8Array,
@@ -50,8 +51,8 @@ export function encodeUpdateVotingSettingsAction(
 function pluginSettingsFromContract(result: Result): VotingSettings {
   return {
     minProposerVotingPower: BigInt(result[0][0]),
-    supportThreshold: parseEtherRatio(result[0][1]),
-    minParticipation: parseEtherRatio(result[0][2]),
+    supportThreshold: decodeRatio(BigInt(result[0][1]), 6),
+    minParticipation: decodeRatio(BigInt(result[0][2]), 6),
     minDuration: result[0][3].toNumber(),
   };
 }
@@ -63,8 +64,8 @@ export function votingSettingsToContract(
     votingMode: BigNumber.from(
       votingModeToContracts(params.votingMode || VotingMode.STANDARD),
     ),
-    supportThreshold: parseEther(params.supportThreshold.toString()),
-    minParticipation: parseEther(params.minParticipation.toString()),
+    supportThreshold: encodeRatio(params.supportThreshold, 6),
+    minParticipation: encodeRatio(params.minParticipation, 6),
     minDuration: BigNumber.from(params.minDuration),
     minProposerVotingPower: BigNumber.from(params.minProposerVotingPower || 0),
   };

--- a/modules/client/src/client-common/utils.ts
+++ b/modules/client/src/client-common/utils.ts
@@ -11,8 +11,6 @@ import { Interface } from "@ethersproject/abi";
 import { id } from "@ethersproject/hash";
 import { Log } from "@ethersproject/providers";
 import { InvalidVotingModeError } from "@aragon/sdk-common";
-import { formatEther } from "@ethersproject/units";
-import { InvalidPrecisionError } from "@aragon/sdk-common";
 
 export function unwrapProposalParams(
   params: ICreateProposalParams,
@@ -111,15 +109,4 @@ export function votingModeToContracts(votingMode: VotingMode): number {
     default:
       throw new InvalidVotingModeError();
   }
-}
-
-export function parseEtherRatio(ether: string, precision: number = 2): number {
-  if (precision <= 0 || !Number.isInteger(precision)) {
-    throw new InvalidPrecisionError()
-  }
-  return parseFloat(
-    parseFloat(
-      formatEther(ether),
-    ).toFixed(precision),
-  );
 }

--- a/modules/client/src/tokenVoting/internal/client/methods.ts
+++ b/modules/client/src/tokenVoting/internal/client/methods.ts
@@ -1,5 +1,6 @@
 import { isAddress } from "@ethersproject/address";
 import {
+  decodeRatio,
   GraphQLError,
   InvalidAddressError,
   InvalidAddressOrEnsError,
@@ -15,7 +16,6 @@ import {
   ClientCore,
   computeProposalStatusFilter,
   ContextPlugin,
-  parseEtherRatio,
   ExecuteProposalStep,
   ExecuteProposalStepValue,
   findLog,
@@ -429,11 +429,13 @@ export class TokenVotingClientMethods extends ClientCore
       }
       return {
         minDuration: parseInt(tokenVotingPlugin.minDuration),
-        supportThreshold: parseEtherRatio(
-          tokenVotingPlugin.supportThreshold,
+        supportThreshold: decodeRatio(
+          BigInt(tokenVotingPlugin.supportThreshold),
+          6,
         ),
-        minParticipation: parseEtherRatio(
-          tokenVotingPlugin.supportThreshold,
+        minParticipation: decodeRatio(
+          BigInt(tokenVotingPlugin.supportThreshold),
+          6,
         ),
         minProposerVotingPower: BigInt(
           tokenVotingPlugin.minParticipation,

--- a/modules/client/src/tokenVoting/internal/utils.ts
+++ b/modules/client/src/tokenVoting/internal/utils.ts
@@ -1,9 +1,8 @@
-import { hexToBytes, strip0x } from "@aragon/sdk-common";
+import { decodeRatio, hexToBytes, strip0x } from "@aragon/sdk-common";
 import {
   computeProposalStatus,
   ContractVotingSettings,
   DaoAction,
-  parseEtherRatio,
   ProposalMetadata,
   SubgraphAction,
   SubgraphVoteValuesMap,
@@ -99,8 +98,8 @@ export function toTokenVotingProposal(
       //   BigInt(proposal.relativeSupportThresholdPct),
       //   2,
       // ),
-      minSupport: parseEtherRatio(proposal.supportThreshold),
-      minTurnout: parseEtherRatio(proposal.minParticipation),
+      minSupport: decodeRatio(BigInt(proposal.supportThreshold), 6),
+      minTurnout: decodeRatio(BigInt(proposal.minParticipation), 6),
       duration: parseInt(proposal.endDate) -
         parseInt(proposal.startDate),
     },


### PR DESCRIPTION
## Description

The smart contracts and subgraph will use 6 digit precision from now on for the `minParticipation` and `supportThreshold`. This means

```
0.05   =>  50000
0.5    =>  500000
1      =>  1000000
```


Task: [APP-1607](https://aragonassociation.atlassian.net/browse/APP-1607)



## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.

[APP-1607]: https://aragonassociation.atlassian.net/browse/APP-1607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ