### PR TITLE
Feature: Add pinMetadata example

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -14,6 +14,8 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+### Added
+- `pinMetadata` examples
 ### Fixed
 - Fix `updateMetadata` decoders
 - Fix `getProposals` ERC721 support on `tokenVotingClient`

--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -15,7 +15,7 @@ TEMPLATE:
 
 ## [UPCOMING]
 ### Added
-- `pinMetadata` examples
+- Add `pinMetadata` examples
 ### Fixed
 - Fix `updateMetadata` decoders
 - Fix `getProposals` ERC721 support on `tokenVotingClient`

--- a/modules/client/examples.md
+++ b/modules/client/examples.md
@@ -485,6 +485,32 @@ for await (const step of steps) {
 }
 ```
 
+### Add and pin metadata
+Adds an pin data with a the format used by aragon app into one of the specified IPFS nodes and return a ipfs cid preceded by ipfs://
+
+```ts
+import { Client, Context, IMetadata } from "@aragon/sdk-client";
+import { contextParams } from "./00-context";
+
+const context = new Context(contextParams);
+const client = new Client(context);
+const metadata: IMetadata = {
+  name: "My DAO",
+  description: "This is a description",
+  avatar: "",
+  links: [{
+    name: "Web site",
+    url: "https://...",
+  }],
+};
+const metadataUri = await client.methods.pinMetadata(metadata);
+console.log(metadataUri);
+
+/*
+  ipfs://Qm...
+*/
+```
+
 ## TokenVoting plugin client
 
 This is a `Client`-like class, tailored to suit the specific use cases of the
@@ -1167,6 +1193,48 @@ console.log(token);
 */
 ```
 
+### Add and pin metadata
+Adds an pin data with a the format used by aragon app into one of the specified IPFS nodes and return a ipfs cid preceded by ipfs://
+
+```ts
+import {
+  TokenVotingClient,
+  Context,
+  ContextPlugin,
+  ProposalMetadata,
+} from "@aragon/sdk-client";
+import { contextParams } from "../00-client/00-context";
+
+const context = new Context(contextParams);
+const contextPlugin = ContextPlugin.fromContext(context);
+const client = new TokenVotingClient(contextPlugin);
+const metadata: ProposalMetadata = {
+  title: "Test Proposal",
+  summary: "This is a short description",
+  description: "This is a long description",
+  resources: [
+    {
+      name: "Discord",
+      url: "https://discord.com/...",
+    },
+    {
+      name: "Website",
+      url: "https://website...",
+    },
+  ],
+  media: {
+    logo: "https://...",
+    header: "https://...",
+  },
+};
+const metadataUri = await client.methods.pinMetadata(metadata);
+console.log(metadataUri);
+
+/*
+  ipfs://Qm...
+*/
+```
+
 ## Address List governance plugin client
 ### Creating a DAO with a addresslistVoting plugin
 
@@ -1741,6 +1809,48 @@ console.log(settings);
     minProposerVotingPower: BigInt("5000"), // default 0
     votingMode: "Standard",
   }
+*/
+```
+
+### Add and pin metadata
+Adds an pin data with a the format used by aragon app into one of the specified IPFS nodes and return a ipfs cid preceded by ipfs://
+
+```ts
+import {
+  AddresslistVotingClient,
+  Context,
+  ContextPlugin,
+  ProposalMetadata,
+} from "@aragon/sdk-client";
+import { contextParams } from "../00-client/00-context";
+
+const context = new Context(contextParams);
+const contextPlugin = ContextPlugin.fromContext(context);
+const client = new AddresslistVotingClient(contextPlugin);
+const metadata: ProposalMetadata = {
+  title: "Test Proposal",
+  summary: "This is a short description",
+  description: "This is a long description",
+  resources: [
+    {
+      name: "Discord",
+      url: "https://discord.com/...",
+    },
+    {
+      name: "Website",
+      url: "https://website...",
+    },
+  ],
+  media: {
+    logo: "https://...",
+    header: "https://...",
+  },
+};
+const metadataUri = await client.methods.pinMetadata(metadata);
+console.log(metadataUri);
+
+/*
+  ipfs://Qm...
 */
 ```
 
@@ -3134,5 +3244,47 @@ console.log(proposals);
     status: "Pending",
   }
 ]
+*/
+```
+
+### Add and pin metadata
+Adds an pin data with a the format used by aragon app into one of the specified IPFS nodes and return a ipfs cid preceded by ipfs://
+
+```ts
+import {
+  Context,
+  ContextPlugin,
+  MultisigClient,
+  ProposalMetadata,
+} from "@aragon/sdk-client";
+import { contextParams } from "../00-client/00-context";
+
+const context = new Context(contextParams);
+const contextPlugin = ContextPlugin.fromContext(context);
+const client = new MultisigClient(contextPlugin);
+const metadata: ProposalMetadata = {
+  title: "Test Proposal",
+  summary: "This is a short description",
+  description: "This is a long description",
+  resources: [
+    {
+      name: "Discord",
+      url: "https://discord.com/...",
+    },
+    {
+      name: "Website",
+      url: "https://website...",
+    },
+  ],
+  media: {
+    logo: "https://...",
+    header: "https://...",
+  },
+};
+const metadataUri = await client.methods.pinMetadata(metadata);
+console.log(metadataUri);
+
+/*
+  ipfs://Qm...
 */
 ```

--- a/modules/client/examples/00-client/10-pin-metadata.ts
+++ b/modules/client/examples/00-client/10-pin-metadata.ts
@@ -1,0 +1,25 @@
+/* MARKDOWN
+### Add and pin metadata
+Adds an pin data with a the format used by aragon app into one of the specified IPFS nodes and return a ipfs cid preceded by ipfs://
+
+*/
+import { Client, Context, IMetadata } from "@aragon/sdk-client";
+import { contextParams } from "./00-context";
+
+const context = new Context(contextParams);
+const client = new Client(context);
+const metadata: IMetadata = {
+  name: "My DAO",
+  description: "This is a description",
+  avatar: "",
+  links: [{
+    name: "Web site",
+    url: "https://...",
+  }],
+};
+const metadataUri = await client.methods.pinMetadata(metadata);
+console.log(metadataUri);
+
+/*
+  ipfs://Qm...
+*/

--- a/modules/client/examples/01-tokenVoting-client/12-pin-metadata.ts
+++ b/modules/client/examples/01-tokenVoting-client/12-pin-metadata.ts
@@ -1,0 +1,41 @@
+/* MARKDOWN
+### Add and pin metadata
+Adds an pin data with a the format used by aragon app into one of the specified IPFS nodes and return a ipfs cid preceded by ipfs://
+
+*/
+import {
+  TokenVotingClient,
+  Context,
+  ContextPlugin,
+  ProposalMetadata,
+} from "@aragon/sdk-client";
+import { contextParams } from "../00-client/00-context";
+
+const context = new Context(contextParams);
+const contextPlugin = ContextPlugin.fromContext(context);
+const client = new TokenVotingClient(contextPlugin);
+const metadata: ProposalMetadata = {
+  title: "Test Proposal",
+  summary: "This is a short description",
+  description: "This is a long description",
+  resources: [
+    {
+      name: "Discord",
+      url: "https://discord.com/...",
+    },
+    {
+      name: "Website",
+      url: "https://website...",
+    },
+  ],
+  media: {
+    logo: "https://...",
+    header: "https://...",
+  },
+};
+const metadataUri = await client.methods.pinMetadata(metadata);
+console.log(metadataUri);
+
+/*
+  ipfs://Qm...
+*/

--- a/modules/client/examples/02-addresslistVoting-client/11-pin-metadata.ts
+++ b/modules/client/examples/02-addresslistVoting-client/11-pin-metadata.ts
@@ -1,0 +1,41 @@
+/* MARKDOWN
+### Add and pin metadata
+Adds an pin data with a the format used by aragon app into one of the specified IPFS nodes and return a ipfs cid preceded by ipfs://
+
+*/
+import {
+  AddresslistVotingClient,
+  Context,
+  ContextPlugin,
+  ProposalMetadata,
+} from "@aragon/sdk-client";
+import { contextParams } from "../00-client/00-context";
+
+const context = new Context(contextParams);
+const contextPlugin = ContextPlugin.fromContext(context);
+const client = new AddresslistVotingClient(contextPlugin);
+const metadata: ProposalMetadata = {
+  title: "Test Proposal",
+  summary: "This is a short description",
+  description: "This is a long description",
+  resources: [
+    {
+      name: "Discord",
+      url: "https://discord.com/...",
+    },
+    {
+      name: "Website",
+      url: "https://website...",
+    },
+  ],
+  media: {
+    logo: "https://...",
+    header: "https://...",
+  },
+};
+const metadataUri = await client.methods.pinMetadata(metadata);
+console.log(metadataUri);
+
+/*
+  ipfs://Qm...
+*/

--- a/modules/client/examples/06-multisig-client/11-pin-metadata.ts
+++ b/modules/client/examples/06-multisig-client/11-pin-metadata.ts
@@ -1,0 +1,41 @@
+/* MARKDOWN
+### Add and pin metadata
+Adds an pin data with a the format used by aragon app into one of the specified IPFS nodes and return a ipfs cid preceded by ipfs://
+
+*/
+import {
+  Context,
+  ContextPlugin,
+  MultisigClient,
+  ProposalMetadata,
+} from "@aragon/sdk-client";
+import { contextParams } from "../00-client/00-context";
+
+const context = new Context(contextParams);
+const contextPlugin = ContextPlugin.fromContext(context);
+const client = new MultisigClient(contextPlugin);
+const metadata: ProposalMetadata = {
+  title: "Test Proposal",
+  summary: "This is a short description",
+  description: "This is a long description",
+  resources: [
+    {
+      name: "Discord",
+      url: "https://discord.com/...",
+    },
+    {
+      name: "Website",
+      url: "https://website...",
+    },
+  ],
+  media: {
+    logo: "https://...",
+    header: "https://...",
+  },
+};
+const metadataUri = await client.methods.pinMetadata(metadata);
+console.log(metadataUri);
+
+/*
+  ipfs://Qm...
+*/


### PR DESCRIPTION
## Description

Currently, there is no example explaining how to pin data on IPFS. 

Also, check if there is an explanation about pinMetadata.

Consider adding a method called pinBytes() or similar instead of expecting people to use client.ipfs.pin(str)

Task: [APP-1503](https://aragonassociation.atlassian.net/browse/APP-1503)

## Type of change

<!--- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.

[APP-1503]: https://aragonassociation.atlassian.net/browse/APP-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ