### PR TITLE
Feature: Split getPluginSetings in getVotingSettings and getMembers

### DIFF
--- a/docs/multisig.md
+++ b/docs/multisig.md
@@ -226,7 +226,8 @@ so that the plugin is configured</p>
     * [.executeProposal(ExecuteProposalParams)](#MultisigClientMethods+executeProposal) ⇒ <code>\*</code>
     * [.canApprove(addressOrEns)](#MultisigClientMethods+canApprove) ⇒ <code>\*</code>
     * [.canExecute(addressOrEns)](#MultisigClientMethods+canExecute) ⇒ <code>\*</code>
-    * [.getPluginSettings(addressOrEns)](#MultisigClientMethods+getPluginSettings) ⇒ <code>\*</code>
+    * [.getVotingSettings(addressOrEns)](#MultisigClientMethods+getVotingSettings) ⇒ <code>\*</code>
+    * [.getMembers(addressOrEns)](#MultisigClientMethods+getMembers) ⇒ <code>\*</code>
     * [.getProposal(proposalId)](#MultisigClientMethods+getProposal) ⇒ <code>\*</code>
     * [.getProposals({)](#MultisigClientMethods+getProposals) ⇒ <code>\*</code>
 
@@ -302,13 +303,25 @@ so that the plugin is configured</p>
 | --- | --- |
 | addressOrEns | <code>string</code> | 
 
-<a name="MultisigClientMethods+getPluginSettings"></a>
+<a name="MultisigClientMethods+getVotingSettings"></a>
 
-### multisigClientMethods.getPluginSettings(addressOrEns) ⇒ <code>\*</code>
-<p>returns the plugin settings</p>
+### multisigClientMethods.getVotingSettings(addressOrEns) ⇒ <code>\*</code>
+<p>returns the voting settings</p>
 
 **Kind**: instance method of [<code>MultisigClientMethods</code>](#MultisigClientMethods)  
-**Returns**: <code>\*</code> - <p>{Promise<MultisigPluginSettings>}</p>  
+**Returns**: <code>\*</code> - <p>{Promise<MultisigVotingSettings>}</p>  
+
+| Param | Type |
+| --- | --- |
+| addressOrEns | <code>string</code> | 
+
+<a name="MultisigClientMethods+getMembers"></a>
+
+### multisigClientMethods.getMembers(addressOrEns) ⇒ <code>\*</code>
+<p>returns the members of the multisig</p>
+
+**Kind**: instance method of [<code>MultisigClientMethods</code>](#MultisigClientMethods)  
+**Returns**: <code>\*</code> - <p>{Promise&lt;string[]&gt;}</p>  
 
 | Param | Type |
 | --- | --- |

--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -14,7 +14,8 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
-
+### Changed
+- Splits `getPluginSettings` in `getVotingSettings` and `getMembers`
 ## [0.18.0-alpha]
 ### Added
 - Add `pinMetadata` examples

--- a/modules/client/examples.md
+++ b/modules/client/examples.md
@@ -3080,7 +3080,7 @@ import {
   Context,
   ContextPlugin,
   MultisigClient,
-  MultisigPluginSettings,
+  MultisigVotingSettings,
 } from "@aragon/sdk-client";
 import { contextParams } from "../00-client/00-context";
 
@@ -3093,18 +3093,11 @@ const client = new MultisigClient(contextPlugin);
 
 const daoAddressorEns = "0x12345...";
 
-const settings: MultisigPluginSettings = await client.methods
-  .getPluginSettings(daoAddressorEns);
+const settings: MultisigVotingSettings = await client.methods
+  .getVotingSettings(daoAddressorEns);
 console.log(settings);
 /*
 {
-  members: [
-    "0x1234567890123456789012345678901234567890",
-    "0x2345678901234567890123456789012345678901",
-    "0x3456789012345678901234567890123456789012",
-    "0x4567890123456789012345678901234567890123",
-    "0x5678901234567890123456789012345678901234",
-  ],
   votingSettings: {
     minApprovals: 4,
     onlyListed: true
@@ -3286,5 +3279,37 @@ console.log(metadataUri);
 
 /*
   ipfs://Qm...
+*/
+```
+
+### Loading the list of members (multisig plugin)
+
+```ts
+import {
+  Context,
+  ContextPlugin,
+  MultisigClient,
+  MultisigVotingSettings,
+} from "@aragon/sdk-client";
+import { contextParams } from "../00-client/00-context";
+
+// Create a simple context
+const context: Context = new Context(contextParams);
+// Create a plugin context from the simple context
+const contextPlugin: ContextPlugin = ContextPlugin.fromContext(context);
+// Create an multisig client
+const client = new MultisigClient(contextPlugin);
+
+const daoAddressorEns = "0x12345...";
+
+const settings: string[] = await client.methods
+  .getMembers(daoAddressorEns);
+console.log(settings);
+/*
+[
+  "0x1234567890...",
+  "0x2345678901...",
+  "0x3456789012...",
+]
 */
 ```

--- a/modules/client/examples/06-multisig-client/08-get-voting-settings.ts
+++ b/modules/client/examples/06-multisig-client/08-get-voting-settings.ts
@@ -1,0 +1,31 @@
+/* MARKDOWN
+### Loading the list of members (multisig plugin)
+*/
+import {
+  Context,
+  ContextPlugin,
+  MultisigClient,
+  MultisigVotingSettings,
+} from "@aragon/sdk-client";
+import { contextParams } from "../00-client/00-context";
+
+// Create a simple context
+const context: Context = new Context(contextParams);
+// Create a plugin context from the simple context
+const contextPlugin: ContextPlugin = ContextPlugin.fromContext(context);
+// Create an multisig client
+const client = new MultisigClient(contextPlugin);
+
+const daoAddressorEns = "0x12345...";
+
+const settings: MultisigVotingSettings = await client.methods
+  .getVotingSettings(daoAddressorEns);
+console.log(settings);
+/*
+{
+  votingSettings: {
+    minApprovals: 4,
+    onlyListed: true
+  }
+}
+*/

--- a/modules/client/examples/06-multisig-client/12-get-members.ts
+++ b/modules/client/examples/06-multisig-client/12-get-members.ts
@@ -5,7 +5,7 @@ import {
   Context,
   ContextPlugin,
   MultisigClient,
-  MultisigPluginSettings,
+  MultisigVotingSettings,
 } from "@aragon/sdk-client";
 import { contextParams } from "../00-client/00-context";
 
@@ -18,21 +18,13 @@ const client = new MultisigClient(contextPlugin);
 
 const daoAddressorEns = "0x12345...";
 
-const settings: MultisigPluginSettings = await client.methods
-  .getPluginSettings(daoAddressorEns);
+const settings: string[] = await client.methods
+  .getMembers(daoAddressorEns);
 console.log(settings);
 /*
-{
-  members: [
-    "0x1234567890123456789012345678901234567890",
-    "0x2345678901234567890123456789012345678901",
-    "0x3456789012345678901234567890123456789012",
-    "0x4567890123456789012345678901234567890123",
-    "0x5678901234567890123456789012345678901234",
-  ],
-  votingSettings: {
-    minApprovals: 4,
-    onlyListed: true
-  }
-}
+[
+  "0x1234567890...",
+  "0x2345678901...",
+  "0x3456789012...",
+]
 */

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "0.18.1-alpha",
+  "version": "0.19.0-alpha",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "0.18.0-alpha",
+  "version": "0.18.1-alpha",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/src/multisig/interfaces.ts
+++ b/modules/client/src/multisig/interfaces.ts
@@ -30,9 +30,12 @@ export interface IMultisigClientMethods extends IClientCore {
   ) => AsyncGenerator<ExecuteProposalStepValue>;
   canApprove: (params: CanApproveParams) => Promise<boolean>;
   canExecute: (params: CanExecuteParams) => Promise<boolean>;
-  getPluginSettings: (
+  getVotingSettings: (
     addressOrEns: string,
-  ) => Promise<MultisigPluginSettings>;
+  ) => Promise<MultisigVotingSettings>;
+  getMembers: (
+    addressOrEns: string,
+  ) => Promise<string[]>;
   getProposal: (propoosalId: string) => Promise<MultisigProposal | null>;
   getProposals: (
     params: IProposalQueryParams,
@@ -162,10 +165,13 @@ export type SubgraphMultisigApproversListItem = {
   approver: { id: string };
 };
 
-export type SubgraphMultisigPluginSettings = {
+export type SubgraphMultisigVotingSettings = {
+  minApprovals: string;
+  onlyListed: boolean;
+};
+
+export type SubgraphMultisigMembers = {
   members: {
     address: string;
   }[];
-  minApprovals: string;
-  onlyListed: boolean;
 };

--- a/modules/client/src/multisig/internal/graphql-queries/members.ts
+++ b/modules/client/src/multisig/internal/graphql-queries/members.ts
@@ -1,0 +1,11 @@
+import { gql } from "graphql-request";
+
+export const QueryMultisigMembers = gql`
+query MultisigMembers($address: ID!) {
+    multisigPlugin(id: $address){
+        members {
+            address
+        }
+    }
+}
+`;

--- a/modules/client/src/multisig/internal/graphql-queries/settings.ts
+++ b/modules/client/src/multisig/internal/graphql-queries/settings.ts
@@ -3,9 +3,6 @@ import { gql } from "graphql-request";
 export const QueryMultisigVotingSettings = gql`
 query MultisigVotingSettings($address: ID!) {
     multisigPlugin(id: $address){
-        members {
-            address
-        }
         minApprovals
         onlyListed
     }

--- a/modules/client/test/integration/multisig-client/methods.test.ts
+++ b/modules/client/test/integration/multisig-client/methods.test.ts
@@ -217,18 +217,33 @@ describe("Client Multisig", () => {
   });
 
   describe("Data retrieval", () => {
-    it("Should get the settings of the plugin", async () => {
+    it("Should get the voting settings of the plugin", async () => {
       const ctx = new Context(contextParams);
       const ctxPlugin = ContextPlugin.fromContext(ctx);
       const client = new MultisigClient(ctxPlugin);
 
-      const settings = await client.methods.getPluginSettings(
+      const settings = await client.methods.getVotingSettings(
         TEST_MULTISIG_PLUGIN_ADDRESS,
       );
       expect(typeof settings).toBe("object");
-      expect(typeof settings.votingSettings.minApprovals).toBe("number");
-      expect(typeof settings.votingSettings.onlyListed).toBe("boolean");
+      expect(typeof settings.minApprovals).toBe("number");
+      expect(typeof settings.onlyListed).toBe("boolean");
     });
+
+    it("Should get members of the multisig", async () => {
+      const ctx = new Context(contextParams);
+      const ctxPlugin = ContextPlugin.fromContext(ctx);
+      const client = new MultisigClient(ctxPlugin);
+
+      const wallets = await client.methods.getMembers(
+        TEST_MULTISIG_PLUGIN_ADDRESS,
+      );
+      expect(Array.isArray(wallets)).toBe(true);
+      expect(wallets.length).toBeGreaterThan(0);
+      expect(typeof wallets[0]).toBe("string");
+      expect(wallets[0]).toMatch(/^0x[A-Fa-f0-9]{40}$/i);
+    });
+
     it("Should fetch the given proposal", async () => {
       const ctx = new Context(contextParams);
       const ctxPlugin = ContextPlugin.fromContext(ctx);


### PR DESCRIPTION
## Description

Splits `getPluginSettings` methods in `getMembers` and `getVotingSettings`

Task: [APP-1675](https://aragonassociation.atlassian.net/browse/APP-1675)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.

[APP-1675]: https://aragonassociation.atlassian.net/browse/APP-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ