### PR TITLE
Fix wrong path for the SDK example generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "docs:multisig": "jsdoc2md --files ./modules/client/src/multisig/*.ts ./modules/client/src/multisig/internal/client/*.ts --configure ./jsdoc2md.json | sed -r 's/(\\{[a-zA-Z]+<[a-zA-Z]+>\\})/`\\1`/mg' > ./docs/02-reference-guide/02-multisig.md",
     "docs:tokenVoting": "jsdoc2md --files ./modules/client/src/tokenVoting/*.ts ./modules/client/src/tokenVoting/internal/client/*.ts --configure ./jsdoc2md.json | sed -r 's/(\\{[a-zA-Z]+<[a-zA-Z]+>\\})/`\\1`/mg' > ./docs/02-reference-guide/03-token-voting.md",
     "docs:addresslistVoting": "jsdoc2md --files ./modules/client/src/addresslistVoting/*.ts ./modules/client/src/addresslistVoting/internal/client/*.ts --configure ./jsdoc2md.json | sed -r 's/(\\{[a-zA-Z]+<[a-zA-Z]+>\\})/`\\1`/mg' > ./docs/02-reference-guide/04-addresslist-voting.md",
-    "docs:examples": "node ./modules/client/scripts/generate-markdown.js ./modules/client/01-examples"
+    "docs:examples": "node ./modules/client/scripts/generate-markdown.js ./modules/client/examples"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",


### PR DESCRIPTION
## Description

Fix wrong path for the examples docs generation

Task [APP-2017](https://aragonassociation.atlassian.net/browse/APP-2017)

[APP-2017]: https://aragonassociation.atlassian.net/browse/APP-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ