### PR TITLE
Feature: Allow to get underlying token and add block number to getMembers

### DIFF
--- a/modules/client-common/src/constants.ts
+++ b/modules/client-common/src/constants.ts
@@ -36,7 +36,7 @@ export const UNAVAILABLE_PROPOSAL_METADATA: ProposalMetadata = {
 const getGraphqlNode = (netowrk: SupportedNetwork): string => {
   return `https://subgraph.satsuma-prod.com/qHR2wGfc5RLi6/aragon/osx-${
     SupportedNetworksToGraphqlNetworks[netowrk]
-  }/api`;
+  }/version/v1.2.0/api`;
 };
 
 export const GRAPHQL_NODES: { [K in SupportedNetwork]: { url: string }[] } = {
@@ -53,13 +53,7 @@ export const GRAPHQL_NODES: { [K in SupportedNetwork]: { url: string }[] } = {
 const IPFS_ENDPOINTS = {
   prod: [
     {
-      url: "https://ipfs-0.aragon.network",
-      headers: {
-        "X-API-KEY": "b477RhECf8s8sdM7XrkLBs2wHc4kCMwpbcFC55Kt",
-      },
-    },
-    {
-      url: "https://ipfs-1.aragon.network",
+      url: "https://prod.ipfs.aragon.network",
       headers: {
         "X-API-KEY": "b477RhECf8s8sdM7XrkLBs2wHc4kCMwpbcFC55Kt",
       },
@@ -67,7 +61,7 @@ const IPFS_ENDPOINTS = {
   ],
   test: [
     {
-      url: "https://testing-ipfs-0.aragon.network",
+      url: "https://test.ipfs.aragon.network",
       headers: {
         "X-API-KEY": "b477RhECf8s8sdM7XrkLBs2wHc4kCMwpbcFC55Kt",
       },

--- a/modules/client-common/test/constants.ts
+++ b/modules/client-common/test/constants.ts
@@ -11,6 +11,5 @@ export const web3endpoints = {
 };
 
 export const DEFAULT_IPFS_ENDPOINTS = [
-  "https://ipfs-0.aragon.network/",
-  "https://ipfs-1.aragon.network/",
+  "https://prod.ipfs.aragon.network/",
 ];

--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -15,7 +15,7 @@ TEMPLATE:
 ## [UPCOMING]
 ### Added
 - Suport for ERC20Wrapper and `underlyingToken`
-- 
+- Add block number to get members query
 ### Changed
 - ContextPlugin is now Context
 - `ContextPlugin.from(Context)` is no longer necessary

--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -13,6 +13,9 @@ TEMPLATE:
 
 -->
 ## [UPCOMING]
+### Added
+- Suport for ERC20Wrapper and `underlyingToken`
+- 
 ### Changed
 - ContextPlugin is now Context
 - `ContextPlugin.from(Context)` is no longer necessary

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/src/addresslistVoting/internal/client/methods.ts
+++ b/modules/client/src/addresslistVoting/internal/client/methods.ts
@@ -311,16 +311,21 @@ export class AddresslistVotingClientMethods extends ClientCore
    *
    * @async
    * @param {string} pluginAddress
+   * @param {number} blockNumber
    * @return {*}  {Promise<string[]>}
    * @memberof AddresslistVotingClientMethods
    */
-  public async getMembers(pluginAddress: string): Promise<string[]> {
+  public async getMembers(
+    pluginAddress: string,
+    blockNumber?: number,
+  ): Promise<string[]> {
     if (!isAddress(pluginAddress)) {
       throw new InvalidAddressError();
     }
     const query = QueryAddresslistVotingMembers;
     const params = {
       address: pluginAddress.toLowerCase(),
+      block: blockNumber ? { number: blockNumber } : null,
     };
     const name = "AddresslistVotingVoting members";
     type T = { addresslistVotingPlugin: SubgraphMembers };

--- a/modules/client/src/addresslistVoting/internal/graphql-queries/members.ts
+++ b/modules/client/src/addresslistVoting/internal/graphql-queries/members.ts
@@ -1,8 +1,8 @@
 import { gql } from "graphql-request";
 
 export const QueryAddresslistVotingMembers = gql`
-query AddresslistVotingMembers($address: ID!) {
-    addresslistVotingPlugin(id: $address){
+query AddresslistVotingMembers($address: ID!, $block: Block_height) {
+    addresslistVotingPlugin(id: $address, block: $block){
         members {
             address
         }

--- a/modules/client/src/addresslistVoting/internal/interfaces.ts
+++ b/modules/client/src/addresslistVoting/internal/interfaces.ts
@@ -40,7 +40,7 @@ export interface IAddresslistVotingClientMethods {
   ) => AsyncGenerator<PrepareInstallationStepValue>;
   canVote: (params: CanVoteParams) => Promise<boolean>;
   canExecute: (proposalId: string) => Promise<boolean>;
-  getMembers: (addressOrEns: string) => Promise<string[]>;
+  getMembers: (addressOrEns: string, blockNumber?: number) => Promise<string[]>;
   getProposal: (
     propoosalId: string,
   ) => Promise<AddresslistVotingProposal | null>;

--- a/modules/client/src/multisig/internal/client/methods.ts
+++ b/modules/client/src/multisig/internal/client/methods.ts
@@ -41,9 +41,7 @@ import {
   ProposalSortBy,
   SubgraphMembers,
 } from "../../../client-common";
-import {
-  Multisig__factory,
-} from "@aragon/osx-ethers";
+import { Multisig__factory } from "@aragon/osx-ethers";
 import {
   QueryMultisigMembers,
   QueryMultisigProposal,
@@ -340,12 +338,14 @@ export class MultisigClientMethods extends ClientCore
   /**
    * returns the members of the multisig
    *
-   * @param {string} addressOrEns
+   * @param {string} pluginAddress
+   * @param {number} blockNumber
    * @return {*}  {Promise<string[]>}
    * @memberof MultisigClientMethods
    */
   public async getMembers(
     pluginAddress: string,
+    blockNumber?: number,
   ): Promise<string[]> {
     // TODO
     // update this with yup validation
@@ -355,6 +355,7 @@ export class MultisigClientMethods extends ClientCore
     const query = QueryMultisigMembers;
     const params = {
       address: pluginAddress.toLowerCase(),
+      block: blockNumber ? { number: blockNumber } : null,
     };
     const name = "Multisig members";
     type T = { multisigPlugin: SubgraphMembers };

--- a/modules/client/src/multisig/internal/graphql-queries/members.ts
+++ b/modules/client/src/multisig/internal/graphql-queries/members.ts
@@ -1,8 +1,8 @@
 import { gql } from "graphql-request";
 
 export const QueryMultisigMembers = gql`
-query MultisigMembers($address: ID!) {
-    multisigPlugin(id: $address){
+query MultisigMembers($address: ID!, $block: Block_height) {
+    multisigPlugin(id: $address, block: $block){
         members {
             address
         }

--- a/modules/client/src/multisig/internal/interfaces.ts
+++ b/modules/client/src/multisig/internal/interfaces.ts
@@ -48,6 +48,7 @@ export interface IMultisigClientMethods {
   ) => Promise<MultisigVotingSettings>;
   getMembers: (
     addressOrEns: string,
+    blockNumber?: number,
   ) => Promise<string[]>;
   getProposal: (proposalId: string) => Promise<MultisigProposal | null>;
   getProposals: (

--- a/modules/client/src/tokenVoting/internal/graphql-queries/token.ts
+++ b/modules/client/src/tokenVoting/internal/graphql-queries/token.ts
@@ -8,6 +8,14 @@ query TokenVotingPlugin($address: ID!) {
       name
       symbol
       __typename
+      ...on ERC20WrapperContract {
+        underlyingToken{
+          id
+          name
+          symbol
+          decimals
+        }
+      }
       ...on ERC20Contract {
         decimals
       }

--- a/modules/client/src/tokenVoting/internal/types.ts
+++ b/modules/client/src/tokenVoting/internal/types.ts
@@ -50,12 +50,18 @@ export enum SubgraphTokenType {
 }
 export enum SubgraphContractType {
   ERC20 = "ERC20Contract",
+  ERC20_WRAPPER = "ERC20WrapperContract",
   ERC721 = "ERC721Contract",
 }
 
 export type SubgraphErc20Token = SubgraphBaseToken & {
   __typename: SubgraphContractType.ERC20;
   decimals: number;
+};
+export type SubgraphErc20WrapperToken = SubgraphBaseToken & {
+  __typename: SubgraphContractType.ERC20_WRAPPER;
+  decimals: number;
+  underlyingToken: SubgraphErc20Token;
 };
 export type SubgraphErc721Token = SubgraphBaseToken & {
   __typename: SubgraphContractType.ERC721;

--- a/modules/client/src/tokenVoting/types.ts
+++ b/modules/client/src/tokenVoting/types.ts
@@ -68,6 +68,10 @@ export type Erc721TokenDetails = TokenBaseDetails & {
   type: TokenType.ERC721;
 };
 
+export type Erc20WrapperTokenDetails = Erc20TokenDetails & {
+  underlyingToken: Erc20TokenDetails;
+};
+
 export type TokenBaseDetails = {
   address: string;
   name: string;

--- a/modules/client/test/integration/addresslistVoting-client/methods.test.ts
+++ b/modules/client/test/integration/addresslistVoting-client/methods.test.ts
@@ -625,13 +625,14 @@ describe("Client Address List", () => {
 
       const wallets = await client.methods.getMembers(
         ADDRESS_ONE,
+        123456,
       );
 
       expect(wallets.length).toBe(1);
       expect(wallets[0]).toBe(ADDRESS_ONE);
       expect(mockedClient.request).toHaveBeenLastCalledWith(
         QueryAddresslistVotingMembers,
-        { address: ADDRESS_ONE },
+        { address: ADDRESS_ONE, block: { number: 123456 } },
       );
     });
     it("Should fetch the given proposal", async () => {

--- a/modules/client/test/integration/multisig-client/methods.test.ts
+++ b/modules/client/test/integration/multisig-client/methods.test.ts
@@ -411,11 +411,13 @@ describe("Client Multisig", () => {
 
       const wallets = await client.methods.getMembers(
         ADDRESS_ONE,
+        123456,
       );
       expect(wallets.length).toBe(2);
       expect(wallets).toMatchObject(members);
       expect(mockedClient.request).toHaveBeenCalledWith(QueryMultisigMembers, {
         address: ADDRESS_ONE,
+        block: { number: 123456 }
       });
     });
 

--- a/modules/client/test/integration/tokenVoting-client/methods.test.ts
+++ b/modules/client/test/integration/tokenVoting-client/methods.test.ts
@@ -1348,8 +1348,8 @@ describe("Token Voting Client", () => {
         expect(token.decimals).toBe(18);
         expect(token.type).toBe(TokenType.ERC20);
         expect(token.underlyingToken.address).toBe(ADDRESS_TWO);
-        expect(token.underlyingToken.name).toBe("TST");
-        expect(token.underlyingToken.symbol).toBe("Test");
+        expect(token.underlyingToken.symbol).toBe("TST");
+        expect(token.underlyingToken.name).toBe("Test");
         expect(token.underlyingToken.decimals).toBe(18);
         expect(token.underlyingToken.type).toBe(TokenType.ERC20);
 

--- a/modules/client/test/integration/tokenVoting-client/methods.test.ts
+++ b/modules/client/test/integration/tokenVoting-client/methods.test.ts
@@ -8,6 +8,7 @@ import {
   CreateMajorityVotingProposalParams,
   DelegateTokensStep,
   Erc20TokenDetails,
+  Erc20WrapperTokenDetails,
   ExecuteProposalStep,
   ProposalCreationSteps,
   ProposalQueryParams,
@@ -1305,6 +1306,52 @@ describe("Token Voting Client", () => {
         expect(token?.symbol).toBe("TST");
         expect(token?.name).toBe("test");
         expect((token as Erc20TokenDetails).decimals).toBe(18);
+
+        expect(mockedClient.request).toHaveBeenCalledWith(
+          QueryTokenVotingPlugin,
+          {
+            address: pluginAddress,
+          },
+        );
+      });
+      it("Should get the token details of a plugin given a plugin instance address with a wrapped token", async () => {
+        const ctx = new Context(contextParamsLocalChain);
+        const client = new TokenVotingClient(ctx);
+        const mockedClient = mockedGraphqlRequest.getMockedInstance(
+          client.graphql.getClient(),
+        );
+        mockedClient.request.mockResolvedValueOnce({
+          tokenVotingPlugin: {
+            token: {
+              id: ADDRESS_THREE,
+              name: "Wrapped Test",
+              symbol: "WTST",
+              decimals: 18,
+              __typename: SubgraphContractType.ERC20_WRAPPER,
+              underlyingToken: {
+                id: ADDRESS_TWO,
+                name: "Test",
+                symbol: "TST",
+                decimals: 18,
+              },
+            },
+          },
+        });
+
+        const pluginAddress: string = ADDRESS_ONE;
+        const token = await client.methods.getToken(
+          pluginAddress,
+        ) as Erc20WrapperTokenDetails;
+        expect(token.address).toBe(ADDRESS_THREE);
+        expect(token.symbol).toBe("WTST");
+        expect(token.name).toBe("Wrapped Test");
+        expect(token.decimals).toBe(18);
+        expect(token.type).toBe(TokenType.ERC20);
+        expect(token.underlyingToken.address).toBe(ADDRESS_TWO);
+        expect(token.underlyingToken.name).toBe("TST");
+        expect(token.underlyingToken.symbol).toBe("Test");
+        expect(token.underlyingToken.decimals).toBe(18);
+        expect(token.underlyingToken.type).toBe(TokenType.ERC20);
 
         expect(mockedClient.request).toHaveBeenCalledWith(
           QueryTokenVotingPlugin,


### PR DESCRIPTION
## Description

Allow to query the underliying token and add block number parameter to `getMembers`

Task: [OS-514](https://aragonassociation.atlassian.net/browse/OS-514)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.

[OS-514]: https://aragonassociation.atlassian.net/browse/OS-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ