### PR TITLE
fix/OS-538-module-path

### DIFF
--- a/modules/client-common/CHANGELOG.md
+++ b/modules/client-common/CHANGELOG.md
@@ -14,6 +14,12 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+
+## 1.0.2
+### Changed
+- Fixed the ESM import path
+
+## 1.0.1
 ### Added
 - Add usage of common errors in all the code
 - Export of OverridenState

--- a/modules/client-common/package.json
+++ b/modules/client-common/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@aragon/sdk-client-common",
   "author": "Aragon Association",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "main": "dist/index.js",
+  "module": "dist/sdk-client-common.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"
@@ -37,14 +38,13 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "module": "dist/plugin-client.esm.js",
   "size-limit": [
     {
-      "path": "dist/plugin-client.cjs.production.min.js",
+      "path": "dist/sdk-client-common.cjs.production.min.js",
       "limit": "10 KB"
     },
     {
-      "path": "dist/plugin-client.esm.js",
+      "path": "dist/sdk-client-common.esm.js",
       "limit": "10 KB"
     }
   ],

--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -13,6 +13,10 @@ TEMPLATE:
 
 -->
 ## [UPCOMING]
+### Changed
+- Bumped the client-common dependency
+
+## [1.9.1]
 ### Added
 - Add usage of common errors in all the code
 ## [1.9.0]

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -63,7 +63,7 @@
     "@aragon/osx-ethers": "^1.2.1",
     "@aragon/sdk-common": "^1.5.0",
     "@aragon/sdk-ipfs": "^1.1.0",
-    "@aragon/sdk-client-common": "^1.0.1",
+    "@aragon/sdk-client-common": "^1.0.2",
     "@ethersproject/abstract-signer": "^5.5.0",
     "@ethersproject/bignumber": "^5.6.0",
     "@ethersproject/constants": "^5.6.0",


### PR DESCRIPTION
## Description

Fixes the ESM import path on SDK client common

Task: OS-538

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
