### PR TITLE
fix(ci): auto publish npm after pushing tags

### DIFF
--- a/.github/workflows/javascript_publish.yml
+++ b/.github/workflows/javascript_publish.yml
@@ -84,9 +84,9 @@ jobs:
         run: python ./.github/scripts/generate_release_notes.py "./modules/${{ needs.check_tag.outputs.package }}/CHANGELOG.md"
       - name: Add NPM pkg info to release-notes.txt
         run: |
-          echo "### NPM Packages" > release-notes.txt
-          echo "- [@aragon/sdk-${{ needs.check_tag.outputs.package }} version ${{ needs.check_tag.outputs.version }}](https://www.npmjs.com/package/@aragon/sdk-${{ needs.check_tag.outputs.package }})" > release-notes.txt
-          echo " " > release-notes.txt
+          echo "### NPM Packages" >> release-notes.txt
+          echo "- [@aragon/sdk-${{ needs.check_tag.outputs.package }} version ${{ needs.check_tag.outputs.version }}](https://www.npmjs.com/package/@aragon/sdk-${{ needs.check_tag.outputs.package }})" >> release-notes.txt
+          echo " " >> release-notes.txt
       - name: Create a Github Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/javascript_publish.yml
+++ b/.github/workflows/javascript_publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Get values (package and verrsion) from Github Tag
+      - name: Get package and version from Github Tag
         id: tag-info
         run: |
           GITHUB_REF="${{ github.ref }}"
@@ -65,7 +65,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build subpackages
         run: yarn run build
-      - name: Publish npm pkg (${{ needs.check_tag.outputs.package }} - ${{ needs.check_tag.outputs.version }})
+      - name: Publish NPM pkg (${{ needs.check_tag.outputs.package }} - ${{ needs.check_tag.outputs.version }})
         run: yarn publish --no-git-tag-version --new-version ${{ needs.check_tag.outputs.version }}
         working-directory: ./modules/${{ needs.check_tag.outputs.package }}
         env:
@@ -74,7 +74,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.x
-          # architecture: "x64"
       # - name: Checkout code (develop branch)
       #   uses: actions/checkout@v3
       #   with:
@@ -87,6 +86,7 @@ jobs:
         run: |
           echo "### NPM Packages" > release-notes.txt
           echo "- [@aragon/sdk-${{ needs.check_tag.outputs.package }} version ${{ needs.check_tag.outputs.version }}](https://www.npmjs.com/package/@aragon/sdk-${{ needs.check_tag.outputs.package }})" > release-notes.txt
+          echo " " > release-notes.txt
       - name: Create a Github Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/javascript_release.yml
+++ b/.github/workflows/javascript_release.yml
@@ -38,7 +38,7 @@ jobs:
           PULL_LABELS: ${{ toJson(github.event.pull_request.labels) }}
 
   release:
-    name: Set Github Tag after PR
+    name: Set Github Tag
     runs-on: ubuntu-latest
     needs: [prepare]
     strategy:
@@ -55,9 +55,10 @@ jobs:
         run: | 
           VERSION=$(cat package.json | jq -r .version)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Set Github Tag
+      - name: Set Github Tag via API
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.ARABOT_PAT }}
           script: |
             github.rest.git.createRef({
               owner: context.repo.owner,


### PR DESCRIPTION
## Description

Added custom PAT to `actions/github-script@v6` in `javascript_release.yml` to allow triggering the second workflow `javascript_publish.yml`. 

Task: [DOPS-532](https://aragonassociation.atlassian.net/browse/DOPS-532)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the ``CHANGELOG.md`` file in the root folder of the package after the [UPCOMING] title and before the latest version.
- [ ] I have tested my code on the test network.

[DOPS-532]: https://aragonassociation.atlassian.net/browse/DOPS-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ