### PR TITLE
Fix: Proposal status and filters for multisig

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -17,6 +17,9 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+### Fixed
+- Bug while filtering multisig propsals by status
+- Bug computing proposal status
 ### Changed
 - Updates `@aragon/osx-ethers` to v1.3.0-rc0.
 

--- a/modules/client/src/client-common/utils.ts
+++ b/modules/client/src/client-common/utils.ts
@@ -76,13 +76,12 @@ export function computeProposalStatusFilter(
       where = { executed: true };
       break;
     case ProposalStatus.SUCCEEDED:
-      where = { potentiallyExecutable: true };
+      where = { potentiallyExecutable: true, endDate_lt: now };
       break;
     case ProposalStatus.DEFEATED:
       where = {
         endDate_lt: now,
         executed: false,
-        potentiallyExecutable: false,
       };
       break;
     default:

--- a/modules/client/src/client-common/utils.ts
+++ b/modules/client/src/client-common/utils.ts
@@ -49,8 +49,8 @@ export function computeProposalStatus(
     return ProposalStatus.PENDING;
   }
   if (
-    (proposal.potentiallyExecutable || proposal.earlyExecutable) &&
-    endDate >= now
+    (now > endDate || proposal.earlyExecutable) &&
+    proposal.potentiallyExecutable
   ) {
     return ProposalStatus.SUCCEEDED;
   }
@@ -67,21 +67,22 @@ export function computeProposalStatusFilter(
   const now = Math.round(new Date().getTime() / 1000).toString();
   switch (status) {
     case ProposalStatus.PENDING:
-      where = { startDate_gte: now };
+      where = { startDate_gte: now, potentiallyExecutable: false, executed: false };
       break;
     case ProposalStatus.ACTIVE:
-      where = { startDate_lt: now, endDate_gte: now, executed: false };
+      where = { startDate_lt: now, endDate_gte: now, executed: false, potentiallyExecutable: false };
       break;
     case ProposalStatus.EXECUTED:
       where = { executed: true };
       break;
     case ProposalStatus.SUCCEEDED:
-      where = { potentiallyExecutable: true, endDate_lt: now };
+      where = { potentiallyExecutable: true };
       break;
     case ProposalStatus.DEFEATED:
       where = {
         endDate_lt: now,
         executed: false,
+        potentiallyExecutable: false,
       };
       break;
     default:

--- a/modules/client/src/client-common/utils.ts
+++ b/modules/client/src/client-common/utils.ts
@@ -70,7 +70,7 @@ export function computeProposalStatusFilter(
       where = { startDate_gte: now, potentiallyExecutable: false, executed: false };
       break;
     case ProposalStatus.ACTIVE:
-      where = { startDate_lt: now, endDate_gte: now, executed: false, potentiallyExecutable: false };
+      where = { startDate_lt: now, endDate_gte: now, executed: false };
       break;
     case ProposalStatus.EXECUTED:
       where = { executed: true };

--- a/modules/client/src/client-common/utils.ts
+++ b/modules/client/src/client-common/utils.ts
@@ -48,7 +48,10 @@ export function computeProposalStatus(
   if (startDate >= now) {
     return ProposalStatus.PENDING;
   }
-  if (proposal.potentiallyExecutable || proposal.earlyExecutable) {
+  if (
+    (proposal.potentiallyExecutable || proposal.earlyExecutable) &&
+    endDate >= now
+  ) {
     return ProposalStatus.SUCCEEDED;
   }
   if (endDate >= now) {
@@ -77,7 +80,6 @@ export function computeProposalStatusFilter(
       break;
     case ProposalStatus.DEFEATED:
       where = {
-        potentiallyExecutable: false,
         endDate_lt: now,
         executed: false,
       };

--- a/modules/client/test/integration/addresslistVoting-client/methods.test.ts
+++ b/modules/client/test/integration/addresslistVoting-client/methods.test.ts
@@ -871,6 +871,7 @@ describe("Client Address List", () => {
           where: {
             endDate_lt: nowFilter,
             executed: false,
+            potentiallyExecutable: false,
           },
           skip: 0,
           limit: params.limit,

--- a/modules/client/test/integration/addresslistVoting-client/methods.test.ts
+++ b/modules/client/test/integration/addresslistVoting-client/methods.test.ts
@@ -869,7 +869,6 @@ describe("Client Address List", () => {
         QueryAddresslistVotingProposals,
         {
           where: {
-            potentiallyExecutable: false,
             endDate_lt: nowFilter,
             executed: false,
           },

--- a/modules/client/test/integration/addresslistVoting-client/methods.test.ts
+++ b/modules/client/test/integration/addresslistVoting-client/methods.test.ts
@@ -871,7 +871,6 @@ describe("Client Address List", () => {
           where: {
             endDate_lt: nowFilter,
             executed: false,
-            potentiallyExecutable: false,
           },
           skip: 0,
           limit: params.limit,

--- a/modules/client/test/integration/multisig-client/methods.test.ts
+++ b/modules/client/test/integration/multisig-client/methods.test.ts
@@ -608,7 +608,6 @@ describe("Client Multisig", () => {
           where: {
             endDate_lt: nowFilter,
             executed: false,
-            potentiallyExecutable: false,
           },
           skip: 0,
           limit: params.limit,

--- a/modules/client/test/integration/multisig-client/methods.test.ts
+++ b/modules/client/test/integration/multisig-client/methods.test.ts
@@ -608,6 +608,7 @@ describe("Client Multisig", () => {
           where: {
             endDate_lt: nowFilter,
             executed: false,
+            potentiallyExecutable: false,
           },
           skip: 0,
           limit: params.limit,

--- a/modules/client/test/integration/multisig-client/methods.test.ts
+++ b/modules/client/test/integration/multisig-client/methods.test.ts
@@ -606,7 +606,6 @@ describe("Client Multisig", () => {
         QueryMultisigProposals,
         {
           where: {
-            potentiallyExecutable: false,
             endDate_lt: nowFilter,
             executed: false,
           },

--- a/modules/client/test/integration/tokenVoting-client/methods.test.ts
+++ b/modules/client/test/integration/tokenVoting-client/methods.test.ts
@@ -1167,6 +1167,7 @@ describe("Token Voting Client", () => {
             where: {
               endDate_lt: nowFilter,
               executed: false,
+              potentiallyExecutable: false,
             },
             skip: 0,
             limit: params.limit,

--- a/modules/client/test/integration/tokenVoting-client/methods.test.ts
+++ b/modules/client/test/integration/tokenVoting-client/methods.test.ts
@@ -1167,7 +1167,6 @@ describe("Token Voting Client", () => {
             where: {
               endDate_lt: nowFilter,
               executed: false,
-              potentiallyExecutable: false,
             },
             skip: 0,
             limit: params.limit,

--- a/modules/client/test/integration/tokenVoting-client/methods.test.ts
+++ b/modules/client/test/integration/tokenVoting-client/methods.test.ts
@@ -1165,7 +1165,6 @@ describe("Token Voting Client", () => {
           QueryTokenVotingProposals,
           {
             where: {
-              potentiallyExecutable: false,
               endDate_lt: nowFilter,
               executed: false,
             },

--- a/modules/client/test/unit/client-common/utils.test.ts
+++ b/modules/client/test/unit/client-common/utils.test.ts
@@ -125,7 +125,7 @@ describe("client-common utils", () => {
       expect(computeProposalStatus({
         endDate: endDate.toString(),
         startDate: startDate.toString(),
-        potentiallyExecutable: false,
+        potentiallyExecutable: true,
         executed: false,
         earlyExecutable: false,
       })).toBe(ProposalStatus.DEFEATED);

--- a/modules/client/test/unit/client-common/utils.test.ts
+++ b/modules/client/test/unit/client-common/utils.test.ts
@@ -95,7 +95,7 @@ describe("client-common utils", () => {
       })).toBe(ProposalStatus.ACTIVE);
     });
     it("should return SUCCEDED if executable = true", () => {
-      const endDate = Date.now() / 1000;
+      const endDate = (Date.now() / 1000) - 300;
       const startDate = (Date.now() / 1000) - 500;
 
       expect(computeProposalStatus({
@@ -113,7 +113,7 @@ describe("client-common utils", () => {
       expect(computeProposalStatus({
         endDate: endDate.toString(),
         startDate: startDate.toString(),
-        potentiallyExecutable: false,
+        potentiallyExecutable: true,
         executed: false,
         earlyExecutable: true,
       })).toBe(ProposalStatus.SUCCEEDED);


### PR DESCRIPTION
## Description

The subgraph sets potentiallyExecutable = true for any multisig proposal where minApproval is 1. So the filters turn up wrong on such cases on this line https://github.com/aragon/sdk/blob/develop/modules/client/src/client-common/utils.ts#L80 (for multisig with minApproval = 1, the defeated condition will be wrong) Also for "Succeeded" in multisig, if the proposal goes past the proposal end date, it should be considered as "Defeated".

An example DAO to check this https://staging-app.aragon.org/#/daos/polygon/0x517b7b401bb0b2c9af9663d0bf7b3688b8cb4fa2/governance

Task ID: [OS-561](https://aragonassociation.atlassian.net/browse/OS-561)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them when possible.
- [ ] I have updated the `CHANGELOG.md` file in the root folder of the package after the `[UPCOMING]` title and before the latest version.
- [ ] I have tested my code on the test network.


[OS-561]: https://aragonassociation.atlassian.net/browse/OS-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ