### PR TITLE
Feature: Add support or plugins prepared but not applied

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -17,6 +17,10 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+### Fixed
+- Underlying tokens queries in getProposal and getProposals
+- Plugins query failing due to prepared but not applied installations
+## [1.10.0-rc1]
 ### Changed
 - Updates `@aragon/osx-ethers` to v1.3.0-rc0.
 

--- a/modules/client/src/internal/types.ts
+++ b/modules/client/src/internal/types.ts
@@ -4,16 +4,16 @@ import { TransferType } from "../types";
 export type SubgraphPluginListItem = {
   appliedPreparation: {
     pluginAddress: string;
-  };
+  } | null;
   appliedPluginRepo: {
     subdomain: string;
-  };
+  } | null; 
   appliedVersion: {
     build: number;
     release: {
       release: number;
     };
-  };
+  } | null;
 };
 
 type SubgraphDaoBase = {

--- a/modules/client/src/internal/utils.ts
+++ b/modules/client/src/internal/utils.ts
@@ -74,18 +74,23 @@ export function toDaoDetails(
     },
     creationDate: new Date(parseInt(dao.createdAt) * 1000),
     // TODO update when new subgraph schema is deployed
-    plugins: dao.plugins.map(
-      (
-        plugin: SubgraphPluginListItem,
-      ): InstalledPluginListItem => (
-        {
-          id: `${plugin.appliedPluginRepo.subdomain}.plugin.dao.eth`,
-          release: plugin.appliedVersion.release.release,
-          build: plugin.appliedVersion.build,
-          instanceAddress: plugin.appliedPreparation.pluginAddress,
-        }
+    // filter out plugins that are not applied
+    plugins: dao.plugins.filter(
+      (plugin) => plugin.appliedPreparation && plugin.appliedVersion && plugin.appliedPluginRepo,
+    )
+      .map(
+        (
+          plugin: SubgraphPluginListItem,
+        ): InstalledPluginListItem => (
+          {
+            // we checked with the filter above that these are not null
+            id: `${plugin.appliedPluginRepo!.subdomain}.plugin.dao.eth`,
+            release: plugin.appliedVersion!.release.release,
+            build: plugin.appliedVersion!.build,
+            instanceAddress: plugin.appliedPreparation!.pluginAddress,
+          }
+        ),
       ),
-    ),
   };
 }
 
@@ -101,15 +106,19 @@ export function toDaoListItem(
       description: metadata.description,
       avatar: metadata.avatar || undefined,
     },
-    plugins: dao.plugins.map(
+    plugins: dao.plugins.filter(
+      (plugin) => plugin.appliedPreparation && plugin.appliedVersion && plugin.appliedPluginRepo,
+    )
+    .map(
       (
         plugin: SubgraphPluginListItem,
       ): InstalledPluginListItem => (
         {
-          id: `${plugin.appliedPluginRepo.subdomain}.plugin.dao.eth`,
-          release: plugin.appliedVersion.release.release,
-          build: plugin.appliedVersion.build,
-          instanceAddress: plugin.appliedPreparation.pluginAddress,
+          // we checked with the filter above that these are not null
+          id: `${plugin.appliedPluginRepo!.subdomain}.plugin.dao.eth`,
+          release: plugin.appliedVersion!.release.release,
+          build: plugin.appliedVersion!.build,
+          instanceAddress: plugin.appliedPreparation!.pluginAddress,
         }
       ),
     ),

--- a/modules/client/test/integration/client/methods.test.ts
+++ b/modules/client/test/integration/client/methods.test.ts
@@ -565,6 +565,11 @@ describe("Client", () => {
                 subdomain: "multisig",
               },
             },
+            {
+              appliedVersion: null,
+              appliedPreparation: null,
+              appliedPluginRepo: null
+            }
           ],
         };
         mockedClient.request.mockResolvedValueOnce({
@@ -582,6 +587,7 @@ describe("Client", () => {
         expect(dao!.plugins[0].instanceAddress).toBe(
           ADDRESS_ONE,
         );
+        expect(dao!.plugins.length).toBe(1);
         expect(dao!.plugins[0].id).toBe("multisig.plugin.dao.eth");
         expect(dao!.plugins[0].build).toBe(1);
         expect(dao!.plugins[0].release).toBe(1);


### PR DESCRIPTION
## Description

At the moment the sdk would crash when a plugin is prepared but not installed, for simplicity matters the dao only shows the fully installed plugins, this PR aims to filter the ones coming from subgraph that are prepared but not applied so it does not crash

Task ID: [OS-542](https://aragonassociation.atlassian.net/browse/OS-542)

## Type of change

<!--- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them when possible.
- [ ] I have updated the `CHANGELOG.md` file in the root folder of the package after the `[UPCOMING]` title and before the latest version.
- [ ] I have tested my code on the test network.


[OS-542]: https://aragonassociation.atlassian.net/browse/OS-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ