### PR TITLE
Fix: Split status functions

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -18,6 +18,9 @@ TEMPLATE:
 
 ## [UPCOMING]
 ### Fixes
+- Fix status calculation for token voting proposals
+## [1.10.1-rc1]
+### Fixes
 - Underlying tokens queries in getProposal and getProposals
 - Plugins query failing due to prepared but not applied installations
 - Ipfs default endpoinst missing api/v0

--- a/modules/client/src/addresslistVoting/internal/client/methods.ts
+++ b/modules/client/src/addresslistVoting/internal/client/methods.ts
@@ -20,7 +20,6 @@ import { isAddress } from "@ethersproject/address";
 import { IAddresslistVotingClientMethods } from "../interfaces";
 import {
   CanVoteParams,
-  computeProposalStatusFilter,
   CreateMajorityVotingProposalParams,
   ExecuteProposalStep,
   ExecuteProposalStepValue,
@@ -45,6 +44,7 @@ import {
 import {
   toAddresslistVotingProposal,
   toAddresslistVotingProposalListItem,
+  computeProposalStatusFilter
 } from "../utils";
 import { AddresslistVoting__factory } from "@aragon/osx-ethers";
 import { toUtf8Bytes } from "@ethersproject/strings";

--- a/modules/client/src/client-common/types/plugin.ts
+++ b/modules/client/src/client-common/types/plugin.ts
@@ -130,14 +130,6 @@ export type SubgraphProposalBase = {
   potentiallyExecutable: boolean;
 };
 
-export interface IComputeStatusProposal {
-  startDate: string;
-  endDate: string;
-  executed: boolean;
-  earlyExecutable?: boolean;
-  potentiallyExecutable: boolean;
-}
-
 export type ProposalQueryParams = Pagination & {
   sortBy?: ProposalSortBy;
   status?: ProposalStatus;

--- a/modules/client/src/multisig/internal/client/methods.ts
+++ b/modules/client/src/multisig/internal/client/methods.ts
@@ -33,7 +33,6 @@ import {
   SubgraphMultisigVotingSettings,
 } from "../types";
 import {
-  computeProposalStatusFilter,
   ExecuteProposalStep,
   ExecuteProposalStepValue,
   ProposalCreationSteps,
@@ -49,7 +48,7 @@ import {
   QueryMultisigProposals,
   QueryMultisigVotingSettings,
 } from "../graphql-queries";
-import { toMultisigProposal, toMultisigProposalListItem } from "../utils";
+import { computeProposalStatusFilter, toMultisigProposal, toMultisigProposalListItem } from "../utils";
 import { toUtf8Bytes } from "@ethersproject/strings";
 import { IMultisigClientMethods } from "../interfaces";
 import {

--- a/modules/client/src/tokenVoting/internal/client/methods.ts
+++ b/modules/client/src/tokenVoting/internal/client/methods.ts
@@ -20,7 +20,6 @@ import {
 } from "@aragon/sdk-common";
 import {
   CanVoteParams,
-  computeProposalStatusFilter,
   CreateMajorityVotingProposalParams,
   ExecuteProposalStep,
   ExecuteProposalStepValue,
@@ -70,6 +69,7 @@ import {
   QueryTokenVotingSettings,
 } from "../graphql-queries";
 import {
+  computeProposalStatusFilter,
   tokenVotingInitParamsToContract,
   toTokenVotingMember,
   toTokenVotingProposal,

--- a/modules/client/test/integration/multisig-client/methods.test.ts
+++ b/modules/client/test/integration/multisig-client/methods.test.ts
@@ -606,7 +606,6 @@ describe("Client Multisig", () => {
         QueryMultisigProposals,
         {
           where: {
-            potentiallyExecutable: false,
             endDate_lt: nowFilter,
             executed: false,
           },

--- a/modules/client/test/unit/addresslistVoting-client/utils.test.ts
+++ b/modules/client/test/unit/addresslistVoting-client/utils.test.ts
@@ -1,0 +1,80 @@
+import { ProposalStatus } from "@aragon/sdk-client-common";
+import { computeProposalStatus } from "../../../src/addresslistVoting/internal/utils";
+import { SubgraphAddresslistVotingProposal } from "../../../src/addresslistVoting/internal/types";
+
+describe("addresslistVoting-client utils", () => {
+  describe("computeProposalStatus", () => {
+    it("should return PENDING", () => {
+      const endDate = Date.now() / 1000;
+      const startDate = (Date.now() / 1000) + 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+        earlyExecutable: false,
+      } as SubgraphAddresslistVotingProposal)).toBe(ProposalStatus.PENDING);
+    });
+    it("should return EXECUTED", () => {
+      const endDate = Date.now() / 1000;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: true,
+        earlyExecutable: false,
+      } as SubgraphAddresslistVotingProposal)).toBe(ProposalStatus.EXECUTED);
+    });
+    it("should return ACTIVE", () => {
+      const endDate = (Date.now() / 1000) + 500;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+        earlyExecutable: false,
+      } as SubgraphAddresslistVotingProposal)).toBe(ProposalStatus.ACTIVE);
+    });
+    it("should return SUCCEDED if executable = true", () => {
+      const endDate = Date.now() / 1000;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: true,
+        executed: false,
+        earlyExecutable: false,
+      } as SubgraphAddresslistVotingProposal)).toBe(ProposalStatus.SUCCEEDED);
+    });
+    it("should return SUCCEDED if earlyExecutable = true", () => {
+      const endDate = (Date.now() / 1000) + 500;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+        earlyExecutable: true,
+      } as SubgraphAddresslistVotingProposal)).toBe(ProposalStatus.SUCCEEDED);
+    });
+    it("should return DEFEATED", () => {
+      const endDate = (Date.now() / 1000) - 200;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+        earlyExecutable: false,
+      } as SubgraphAddresslistVotingProposal)).toBe(ProposalStatus.DEFEATED);
+    });
+  });
+});

--- a/modules/client/test/unit/client-common/utils.test.ts
+++ b/modules/client/test/unit/client-common/utils.test.ts
@@ -4,7 +4,7 @@ import {
 } from "../../../src";
 import { Multisig__factory } from "@aragon/osx-ethers";
 import { id } from "@ethersproject/hash";
-import { DaoAction, ProposalStatus } from "@aragon/sdk-client-common";
+import { DaoAction } from "@aragon/sdk-client-common";
 
 const UPDATE_MULTISIG_SETTINGS_ACTION = {
   value: BigInt(0),

--- a/modules/client/test/unit/client-common/utils.test.ts
+++ b/modules/client/test/unit/client-common/utils.test.ts
@@ -1,6 +1,5 @@
 import { hexToBytes } from "@aragon/sdk-common";
 import {
-  computeProposalStatus,
   isFailingProposal,
 } from "../../../src";
 import { Multisig__factory } from "@aragon/osx-ethers";
@@ -56,82 +55,6 @@ const UPGRADE_TO_ACTION = {
   ),
 };
 
-describe("client-common utils", () => {
-  describe("computeProposalStatus", () => {
-    it("should return PENDING", () => {
-      const endDate = Date.now() / 1000;
-      const startDate = (Date.now() / 1000) + 500;
-
-      expect(computeProposalStatus({
-        endDate: endDate.toString(),
-        startDate: startDate.toString(),
-        potentiallyExecutable: false,
-        executed: false,
-        earlyExecutable: false,
-      })).toBe(ProposalStatus.PENDING);
-    });
-    it("should return EXECUTED", () => {
-      const endDate = Date.now() / 1000;
-      const startDate = (Date.now() / 1000) - 500;
-
-      expect(computeProposalStatus({
-        endDate: endDate.toString(),
-        startDate: startDate.toString(),
-        potentiallyExecutable: false,
-        executed: true,
-        earlyExecutable: false,
-      })).toBe(ProposalStatus.EXECUTED);
-    });
-    it("should return ACTIVE", () => {
-      const endDate = (Date.now() / 1000) + 500;
-      const startDate = (Date.now() / 1000) - 500;
-
-      expect(computeProposalStatus({
-        endDate: endDate.toString(),
-        startDate: startDate.toString(),
-        potentiallyExecutable: false,
-        executed: false,
-        earlyExecutable: false,
-      })).toBe(ProposalStatus.ACTIVE);
-    });
-    it("should return SUCCEDED if executable = true", () => {
-      const endDate = Date.now() / 1000;
-      const startDate = (Date.now() / 1000) - 500;
-
-      expect(computeProposalStatus({
-        endDate: endDate.toString(),
-        startDate: startDate.toString(),
-        potentiallyExecutable: true,
-        executed: false,
-        earlyExecutable: false,
-      })).toBe(ProposalStatus.SUCCEEDED);
-    });
-    it("should return SUCCEDED if earlyExecutable = true", () => {
-      const endDate = (Date.now() / 1000) + 500;
-      const startDate = (Date.now() / 1000) - 500;
-
-      expect(computeProposalStatus({
-        endDate: endDate.toString(),
-        startDate: startDate.toString(),
-        potentiallyExecutable: false,
-        executed: false,
-        earlyExecutable: true,
-      })).toBe(ProposalStatus.SUCCEEDED);
-    });
-    it("should return DEFEATED", () => {
-      const endDate = (Date.now() / 1000) - 200;
-      const startDate = (Date.now() / 1000) - 500;
-
-      expect(computeProposalStatus({
-        endDate: endDate.toString(),
-        startDate: startDate.toString(),
-        potentiallyExecutable: false,
-        executed: false,
-        earlyExecutable: false,
-      })).toBe(ProposalStatus.DEFEATED);
-    });
-  });
-});
 
 describe("Detect failing proposals", () => {
   it("isFailingProposal should return true because the proposal changes the min approvals and then updates the addresses", async () => {

--- a/modules/client/test/unit/multisig-client/utils.test.ts
+++ b/modules/client/test/unit/multisig-client/utils.test.ts
@@ -1,0 +1,63 @@
+import { ProposalStatus } from "@aragon/sdk-client-common";
+import { computeProposalStatus } from "../../../src/multisig/internal/utils";
+import { SubgraphMultisigProposal } from "../../../src/multisig/internal/types";
+
+describe("multisig-client utils", () => {
+  describe("computeProposalStatus", () => {
+    it("should return PENDING", () => {
+      const endDate = Date.now() / 1000;
+      const startDate = (Date.now() / 1000) + 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+      } as SubgraphMultisigProposal)).toBe(ProposalStatus.PENDING);
+    });
+    it("should return EXECUTED", () => {
+      const endDate = Date.now() / 1000;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: true,
+      } as SubgraphMultisigProposal)).toBe(ProposalStatus.EXECUTED);
+    });
+    it("should return ACTIVE", () => {
+      const endDate = (Date.now() / 1000) + 500;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+      } as SubgraphMultisigProposal)).toBe(ProposalStatus.ACTIVE);
+    });
+    it("should return SUCCEDED if executable = true", () => {
+      const endDate = (Date.now() / 1000) + 500;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: true,
+        executed: false,
+      } as SubgraphMultisigProposal)).toBe(ProposalStatus.SUCCEEDED);
+    });
+    it("should return DEFEATED", () => {
+      const endDate = (Date.now() / 1000) - 200;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: true,
+        executed: false,
+      } as SubgraphMultisigProposal)).toBe(ProposalStatus.DEFEATED);
+    });
+  });
+});

--- a/modules/client/test/unit/tokenVoting-client  /utils.test.ts
+++ b/modules/client/test/unit/tokenVoting-client  /utils.test.ts
@@ -1,6 +1,6 @@
-import { TokenType } from "@aragon/sdk-client-common";
-import { SubgraphContractType } from "../../../src/tokenVoting/internal/types";
-import { parseToken } from "../../../src/tokenVoting/internal/utils";
+import { ProposalStatus, TokenType } from "@aragon/sdk-client-common";
+import { SubgraphContractType, SubgraphTokenVotingProposal } from "../../../src/tokenVoting/internal/types";
+import { computeProposalStatus, parseToken } from "../../../src/tokenVoting/internal/utils";
 
 describe("tokenVoting-client utils", () => {
   describe("parseToken", () => {
@@ -73,6 +73,80 @@ describe("tokenVoting-client utils", () => {
             symbol: "TT",
         });
         expect(token).toEqual(null);
+    });
+  });
+  describe("computeProposalStatus", () => {
+    it("should return PENDING", () => {
+      const endDate = Date.now() / 1000;
+      const startDate = (Date.now() / 1000) + 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+        earlyExecutable: false,
+      } as SubgraphTokenVotingProposal)).toBe(ProposalStatus.PENDING);
+    });
+    it("should return EXECUTED", () => {
+      const endDate = Date.now() / 1000;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: true,
+        earlyExecutable: false,
+      } as SubgraphTokenVotingProposal)).toBe(ProposalStatus.EXECUTED);
+    });
+    it("should return ACTIVE", () => {
+      const endDate = (Date.now() / 1000) + 500;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+        earlyExecutable: false,
+      } as SubgraphTokenVotingProposal)).toBe(ProposalStatus.ACTIVE);
+    });
+    it("should return SUCCEDED if executable = true", () => {
+      const endDate = Date.now() / 1000;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: true,
+        executed: false,
+        earlyExecutable: false,
+      } as SubgraphTokenVotingProposal)).toBe(ProposalStatus.SUCCEEDED);
+    });
+    it("should return SUCCEDED if earlyExecutable = true", () => {
+      const endDate = (Date.now() / 1000) + 500;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+        earlyExecutable: true,
+      } as SubgraphTokenVotingProposal)).toBe(ProposalStatus.SUCCEEDED);
+    });
+    it("should return DEFEATED", () => {
+      const endDate = (Date.now() / 1000) - 200;
+      const startDate = (Date.now() / 1000) - 500;
+
+      expect(computeProposalStatus({
+        endDate: endDate.toString(),
+        startDate: startDate.toString(),
+        potentiallyExecutable: false,
+        executed: false,
+        earlyExecutable: false,
+      } as SubgraphTokenVotingProposal)).toBe(ProposalStatus.DEFEATED);
     });
   });
 });


### PR DESCRIPTION
## Description
The statuses shoud be computed differently accreoss plugins this removes the function from the common utils and splits  it in 3 different functions one for each plugin

Task ID: [OS-561](https://aragonassociation.atlassian.net/browse/OS-561)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them when possible.
- [ ] I have updated the `CHANGELOG.md` file in the root folder of the package after the `[UPCOMING]` title and before the latest version.
- [ ] I have tested my code on the test network.


[OS-561]: https://aragonassociation.atlassian.net/browse/OS-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ