### PR TITLE
Make the network mandatory on get plugin install item

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -24,6 +24,8 @@ TEMPLATE:
 - Underlying tokens queries in getProposal and getProposals
 - Plugins query failing due to prepared but not applied installations
 - Ipfs default endpoinst missing api/v0
+- Make the `network` parameter required on `getPluginInstallItem`
+
 ## [1.10.0-rc1]
 ### Fixes
 - Update common-client version

--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -19,12 +19,12 @@ TEMPLATE:
 ## [UPCOMING]
 ### Fixes
 - Fix status calculation for token voting proposals
+- Make the `network` parameter required on `getPluginInstallItem`
 ## [1.10.1-rc1]
 ### Fixes
 - Underlying tokens queries in getProposal and getProposals
 - Plugins query failing due to prepared but not applied installations
 - Ipfs default endpoinst missing api/v0
-- Make the `network` parameter required on `getPluginInstallItem`
 
 ## [1.10.0-rc1]
 ### Fixes

--- a/modules/client/examples/01-client/01-create-dao.ts
+++ b/modules/client/examples/01-client/01-create-dao.ts
@@ -62,7 +62,7 @@ const tokenVotingPluginInstallParams: TokenVotingPluginInstall = {
 
 // Creates a TokenVoting plugin client with the parameteres defined above (with an existing token).
 const tokenVotingInstallItem = TokenVotingClient.encoding
-  .getPluginInstallItem(tokenVotingPluginInstallParams);
+  .getPluginInstallItem(tokenVotingPluginInstallParams, "goerli");
 
 const createDaoParams: CreateDaoParams = {
   metadataUri,

--- a/modules/client/examples/02-multisig-client/01-installation.ts
+++ b/modules/client/examples/02-multisig-client/01-installation.ts
@@ -42,7 +42,7 @@ const multisigPluginIntallParams: MultisigPluginInstallParams = {
 
 // Encodes the parameters of the Multisig plugin. These will get used in the installation plugin for the DAO.
 const multisigPluginInstallItem = MultisigClient.encoding
-  .getPluginInstallItem(multisigPluginIntallParams);
+  .getPluginInstallItem(multisigPluginIntallParams, "goerli");
 
 // Pin metadata to IPFS, returns IPFS CID string.
 const metadataUri: string = await client.methods.pinMetadata({

--- a/modules/client/examples/03-tokenVoting-client/01-installation.ts
+++ b/modules/client/examples/03-tokenVoting-client/01-installation.ts
@@ -75,10 +75,10 @@ const tokenVotingPluginInstallParams2: TokenVotingPluginInstall = {
 
 // Creates a TokenVoting plugin client with the parameteres defined above (with an existing token).
 const tokenVotingPluginInstallItem1 = TokenVotingClient.encoding
-  .getPluginInstallItem(tokenVotingPluginInstallParams1);
+  .getPluginInstallItem(tokenVotingPluginInstallParams1, "goerli");
 // Creates a TokenVoting plugin client with the parameteres defined above (with newly minted tokens).
 const tokenVotingPluginInstallItem2 = TokenVotingClient.encoding
-  .getPluginInstallItem(tokenVotingPluginInstallParams2);
+  .getPluginInstallItem(tokenVotingPluginInstallParams2, "goerli");
 
 const daoMetadata: DaoMetadata = {
   name: "My DAO",

--- a/modules/client/examples/04-addresslistVoting-client/01-installation.ts
+++ b/modules/client/examples/04-addresslistVoting-client/01-installation.ts
@@ -45,7 +45,7 @@ const addresslistVotingPluginInstallParams: AddresslistVotingPluginInstall = {
 
 // Encodes the plugin instructions for installing into the DAO with its defined parameters.
 const addresslistVotingPluginInstallItem = AddresslistVotingClient
-  .encoding.getPluginInstallItem(addresslistVotingPluginInstallParams);
+  .encoding.getPluginInstallItem(addresslistVotingPluginInstallParams, "goerli");
 
 const daoMetadata: DaoMetadata = {
   name: "My DAO",

--- a/modules/client/src/addresslistVoting/client.ts
+++ b/modules/client/src/addresslistVoting/client.ts
@@ -43,7 +43,7 @@ export class AddresslistVotingClient extends ClientCore
      */
     getPluginInstallItem: (
       params: AddresslistVotingPluginInstall,
-      network: Networkish = "mainnet",
+      network: Networkish,
     ): PluginInstallItem =>
       AddresslistVotingClientEncoding.getPluginInstallItem(params, network),
   };

--- a/modules/client/src/multisig/client.ts
+++ b/modules/client/src/multisig/client.ts
@@ -43,7 +43,7 @@ export class MultisigClient extends ClientCore implements IMultisigClient {
 
     getPluginInstallItem: (
       params: MultisigPluginInstallParams,
-      network: Networkish = "mainnet",
+      network: Networkish,
     ): PluginInstallItem =>
       MultisigClientEncoding.getPluginInstallItem(params, network),
   };

--- a/modules/client/src/tokenVoting/client.ts
+++ b/modules/client/src/tokenVoting/client.ts
@@ -46,7 +46,7 @@ export class TokenVotingClient extends ClientCore
      */
     getPluginInstallItem: (
       params: TokenVotingPluginInstall,
-      network: Networkish = "mainnet",
+      network: Networkish,
     ): PluginInstallItem =>
       TokenVotingClientEncoding.getPluginInstallItem(params, network),
   };

--- a/modules/client/test/helpers/build-daos.ts
+++ b/modules/client/test/helpers/build-daos.ts
@@ -16,6 +16,8 @@ import {
 import { TokenVoting__factory } from "@aragon/osx-ethers";
 import { Context } from "@aragon/sdk-client-common";
 
+const NETWORK_NAME = "goerli";
+
 export async function buildMultisigDAO(pluginRepoAddress: string) {
   const client = new Client(new Context(contextParamsLocalChain));
 
@@ -26,7 +28,7 @@ export async function buildMultisigDAO(pluginRepoAddress: string) {
         minApprovals: 1,
         onlyListed: true,
       },
-    }, client.web3.getProvider().network.name);
+    }, NETWORK_NAME);
 
   const createDaoParams: CreateDaoParams = {
     ensSubdomain: "teting-" + Math.random().toString().slice(2),
@@ -80,7 +82,7 @@ export async function buildTokenVotingDAO(
   const pluginInstallItem = TokenVotingClient.encoding
     .getPluginInstallItem(
       pluginInstallParams,
-      client.web3.getProvider().network.name
+      NETWORK_NAME
     );
 
   const createDaoParams: CreateDaoParams = {
@@ -144,7 +146,7 @@ export async function buildExistingTokenVotingDAO(
         minProposerVotingPower: BigInt(0),
         votingMode,
       },
-    }, client.web3.getProvider().network.name);
+    }, NETWORK_NAME);
 
   const createDaoParams: CreateDaoParams = {
     ensSubdomain: "teting-" + Math.random().toString().slice(2),
@@ -190,7 +192,7 @@ export async function buildAddressListVotingDAO(
         minProposerVotingPower: BigInt(0),
         votingMode,
       },
-    }, client.web3.getProvider().network.name);
+    }, NETWORK_NAME);
 
   const createDaoParams: CreateDaoParams = {
     ensSubdomain: "teting-" + Math.random().toString().slice(2),

--- a/modules/client/test/helpers/build-daos.ts
+++ b/modules/client/test/helpers/build-daos.ts
@@ -26,7 +26,7 @@ export async function buildMultisigDAO(pluginRepoAddress: string) {
         minApprovals: 1,
         onlyListed: true,
       },
-    });
+    }, client.web3.getProvider().network.name);
 
   const createDaoParams: CreateDaoParams = {
     ensSubdomain: "teting-" + Math.random().toString().slice(2),
@@ -78,7 +78,10 @@ export async function buildTokenVotingDAO(
     },
   };
   const pluginInstallItem = TokenVotingClient.encoding
-    .getPluginInstallItem(pluginInstallParams);
+    .getPluginInstallItem(
+      pluginInstallParams,
+      client.web3.getProvider().network.name
+    );
 
   const createDaoParams: CreateDaoParams = {
     ensSubdomain: "teting-" + Math.random().toString().slice(2),
@@ -141,7 +144,7 @@ export async function buildExistingTokenVotingDAO(
         minProposerVotingPower: BigInt(0),
         votingMode,
       },
-    });
+    }, client.web3.getProvider().network.name);
 
   const createDaoParams: CreateDaoParams = {
     ensSubdomain: "teting-" + Math.random().toString().slice(2),
@@ -187,7 +190,7 @@ export async function buildAddressListVotingDAO(
         minProposerVotingPower: BigInt(0),
         votingMode,
       },
-    });
+    }, client.web3.getProvider().network.name);
 
   const createDaoParams: CreateDaoParams = {
     ensSubdomain: "teting-" + Math.random().toString().slice(2),

--- a/modules/client/test/helpers/deployContracts.ts
+++ b/modules/client/test/helpers/deployContracts.ts
@@ -445,7 +445,7 @@ export async function createAddresslistDAO(
       votingMode,
       minProposerVotingPower: BigInt(0),
     },
-  });
+  }, (await deployment.daoFactory.provider.getNetwork()).name);
 
   const pluginInstallItems = [
     {

--- a/modules/client/test/integration/addresslistVoting-client/encoding.test.ts
+++ b/modules/client/test/integration/addresslistVoting-client/encoding.test.ts
@@ -10,9 +10,11 @@ import { bytesToHex, InvalidAddressError } from "@aragon/sdk-common";
 import { ADDRESS_ONE, contextParamsLocalChain } from "../constants";
 import { Context, SupportedNetworksArray } from "@aragon/sdk-client-common";
 
+const NETWORK_NAME = "goerli";
+
 jest.spyOn(SupportedNetworksArray, "includes").mockReturnValue(true);
 jest.spyOn(Context.prototype, "network", "get").mockReturnValue(
-  { chainId: 5, name: "goerli" },
+  { chainId: 5, name: NETWORK_NAME },
 );
 describe("Client Address List", () => {
   beforeAll(() => {
@@ -37,6 +39,7 @@ describe("Client Address List", () => {
       const installPluginItemItem = AddresslistVotingClient.encoding
         .getPluginInstallItem(
           withdrawParams,
+          NETWORK_NAME,
         );
 
       expect(typeof installPluginItemItem).toBe("object");

--- a/modules/client/test/integration/client/estimation.test.ts
+++ b/modules/client/test/integration/client/estimation.test.ts
@@ -20,9 +20,11 @@ import {
   TokenType,
 } from "@aragon/sdk-client-common";
 
+const NETWORK_NAME = "goerli";
+
 jest.spyOn(SupportedNetworksArray, "includes").mockReturnValue(true);
 jest.spyOn(Context.prototype, "network", "get").mockReturnValue(
-  { chainId: 5, name: "goerli" },
+  { chainId: 5, name: NETWORK_NAME },
 );
 let daoAddress = "0x1234567890123456789012345678901234567890";
 describe("Client", () => {
@@ -62,7 +64,7 @@ describe("Client", () => {
       };
 
       const addresslistVotingPlugin = AddresslistVotingClient.encoding
-        .getPluginInstallItem(pluginParams);
+        .getPluginInstallItem(pluginParams, NETWORK_NAME);
       addresslistVotingPlugin.id = deployment.addresslistVotingRepo.address;
 
       const daoCreationParams: CreateDaoParams = {

--- a/modules/client/test/integration/client/methods.test.ts
+++ b/modules/client/test/integration/client/methods.test.ts
@@ -72,9 +72,11 @@ import {
 } from "@aragon/sdk-client-common";
 import { INSTALLATION_ABI } from "../../../src/multisig/internal/constants";
 
+const NETWORK_NAME = "goerli";
+
 jest.spyOn(SupportedNetworksArray, "includes").mockReturnValue(true);
 jest.spyOn(Context.prototype, "network", "get").mockReturnValue(
-  { chainId: 5, name: "goerli" },
+  { chainId: 5, name: NETWORK_NAME },
 );
 describe("Client", () => {
   let daoAddress: string;
@@ -144,7 +146,7 @@ describe("Client", () => {
         };
 
         const addresslistVotingPlugin = AddresslistVotingClient.encoding
-          .getPluginInstallItem(pluginParams);
+          .getPluginInstallItem(pluginParams, NETWORK_NAME);
         addresslistVotingPlugin.id = deployment.addresslistVotingRepo.address;
 
         const daoCreationParams: CreateDaoParams = {

--- a/modules/client/test/integration/multisig-client/encoding.test.ts
+++ b/modules/client/test/integration/multisig-client/encoding.test.ts
@@ -15,9 +15,11 @@ import {
 } from "../constants";
 import { Context, SupportedNetworksArray } from "@aragon/sdk-client-common";
 
+const NETWORK_NAME = "goerli";
+
 jest.spyOn(SupportedNetworksArray, "includes").mockReturnValue(true);
 jest.spyOn(Context.prototype, "network", "get").mockReturnValue(
-  { chainId: 5, name: "goerli" },
+  { chainId: 5, name: NETWORK_NAME },
 );
 
 describe("Client Multisig", () => {
@@ -43,6 +45,7 @@ describe("Client Multisig", () => {
       const installPluginItemItem = MultisigClient.encoding
         .getPluginInstallItem(
           multisigIntallParams,
+          NETWORK_NAME
         );
 
       expect(typeof installPluginItemItem).toBe("object");

--- a/modules/client/test/integration/tokenVoting-client/encoding.test.ts
+++ b/modules/client/test/integration/tokenVoting-client/encoding.test.ts
@@ -12,9 +12,11 @@ import { InvalidAddressError } from "@aragon/sdk-common";
 import { ADDRESS_ONE, contextParamsLocalChain } from "../constants";
 import { Context, SupportedNetworksArray } from "@aragon/sdk-client-common";
 
+const NETWORK_NAME = "goerli";
+
 jest.spyOn(SupportedNetworksArray, "includes").mockReturnValue(true);
 jest.spyOn(Context.prototype, "network", "get").mockReturnValue(
-  { chainId: 5, name: "goerli" },
+  { chainId: 5, name: NETWORK_NAME },
 );
 
 describe("Token Voting Client", () => {
@@ -39,6 +41,7 @@ describe("Token Voting Client", () => {
       const tokenVotingInstallPluginItem = TokenVotingClient.encoding
         .getPluginInstallItem(
           initParams,
+          NETWORK_NAME
         );
 
       expect(typeof tokenVotingInstallPluginItem).toBe("object");


### PR DESCRIPTION
## Description

The current implementation leads developers to confusion when the network parameter is omitted on `getPluginInstallItem`

Task ID: [OS-610]()

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them when possible.
- [ ] I have updated the `CHANGELOG.md` file in the root folder of the package after the `[UPCOMING]` title and before the latest version.
- [ ] I have tested my code on the test network.


[OS-610]: https://aragonassociation.atlassian.net/browse/OS-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ