### PR TITLE
Chore: Changing voters and approvers count to 1000 from the default value of 100

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -18,6 +18,7 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+- Chore: Changed voters and approvers count to 1000 from the default value of 100 in Proposal Queries
 
 ### Changed
 

--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -18,8 +18,11 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+
+### Changed
 - Chore: Changed voters and approvers count to 1000 from the default value of 100 in Proposal Queries
 
+## [1.21.0]
 ### Changed
 
 -Update `osx-ethers` to v1.3.0

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/src/multisig/internal/graphql-queries/proposal.ts
+++ b/modules/client/src/multisig/internal/graphql-queries/proposal.ts
@@ -29,7 +29,7 @@ query MultisigProposal($proposalId: ID!) {
     executed
     approvalReached
     isSignaling
-    approvers{
+    approvers(first: 1000){
       id
     }
   }

--- a/modules/client/src/tokenVoting/internal/graphql-queries/proposal.ts
+++ b/modules/client/src/tokenVoting/internal/graphql-queries/proposal.ts
@@ -31,7 +31,7 @@ query TokenVotingProposal($proposalId: ID!) {
     approvalReached
     isSignaling
     executionTxHash
-    voters{
+    voters(first: 1000){
       voter{
         address
       }


### PR DESCRIPTION
## Description

We need the count of `voters` and `approvers` on the `tokenVotingProposal` and `multisigProposal` entities to enable pagination and also display the count on the UI without doing multiple queries. Till then using this `first: 1000` hack to solve the issue ASAP. @josemarinas @Rekard0 


## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them when possible.
- [ ] I have updated the `CHANGELOG.md` file in the root folder of the package after the `[UPCOMING]` title and before the latest version.
- [x] I have tested my code on the test network.
