### PR TITLE
fix: wrong root permission check

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -18,6 +18,10 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+### Fixed
+- Compare with dao address in `validatePluginUpdateProposal`
+
+## [1.21.1]
 
 ### Changed
 - Chore: Changed voters and approvers count to 1000 from the default value of 100 in Proposal Queries

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/src/internal/utils.ts
+++ b/modules/client/src/internal/utils.ts
@@ -1033,13 +1033,16 @@ export function validateGrantRootPermissionAction(
     );
   }
   // The action should be sent to the DAO
+  // both come from subgraph so they are already lowercase
   if (action.to !== daoAddress) {
     causes.push(
       PluginUpdateProposalInValidityCause
         .INVALID_GRANT_ROOT_PERMISSION_TO_ADDRESS,
     );
   }
-  if (decodedPermission.where !== daoAddress) {
+  // decodedPermission.where is checksummed so we need to lowercase it
+  // to compare it with the daoAddress because it comes from the subgraph
+  if (decodedPermission.where.toLowerCase() !== daoAddress) {
     causes.push(
       PluginUpdateProposalInValidityCause
         .INVALID_GRANT_ROOT_PERMISSION_WHERE_ADDRESS,

--- a/modules/client/test/unit/client/utils.test.ts
+++ b/modules/client/test/unit/client/utils.test.ts
@@ -432,7 +432,7 @@ describe("Test client utils", () => {
     });
     it("should return an error if the permission is not granted in the DAO", () => {
       const grantAction = client.encoding.grantAction(daoAddress, {
-        where: daoAddress,
+        where: pluginAddress,
         who: pspAddress,
         permission: Permissions.ROOT_PERMISSION,
       });
@@ -565,7 +565,7 @@ describe("Test client utils", () => {
     });
     it("should return an error if the permission is not revoked in the DAO", () => {
       const revokeAction = client.encoding.revokeAction(daoAddress, {
-        where: daoAddress,
+        where: pluginAddress,
         who: pspAddress,
         permission: Permissions.ROOT_PERMISSION,
       });

--- a/modules/client/test/unit/client/utils.test.ts
+++ b/modules/client/test/unit/client/utils.test.ts
@@ -432,7 +432,7 @@ describe("Test client utils", () => {
     });
     it("should return an error if the permission is not granted in the DAO", () => {
       const grantAction = client.encoding.grantAction(daoAddress, {
-        where: pluginAddress,
+        where: daoAddress,
         who: pspAddress,
         permission: Permissions.ROOT_PERMISSION,
       });
@@ -565,7 +565,7 @@ describe("Test client utils", () => {
     });
     it("should return an error if the permission is not revoked in the DAO", () => {
       const revokeAction = client.encoding.revokeAction(daoAddress, {
-        where: pluginAddress,
+        where: daoAddress,
         who: pspAddress,
         permission: Permissions.ROOT_PERMISSION,
       });


### PR DESCRIPTION
## Description

The security check failed for a correct update proposal. The problem was not visible in production because none of our plugin updates conducts permission changes and therefore doesn't require `ROOT_PERMISSION_ID`.

Task ID: [OS-936](https://aragonassociation.atlassian.net/browse/OS-936)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them when possible.
- [ ] I have updated the `CHANGELOG.md` file in the root folder of the package after the `[UPCOMING]` title and before the latest version.
- [ ] I have tested my code on the test network.


[OS-936]: https://aragonassociation.atlassian.net/browse/OS-936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ