### PR TITLE
fix: wrong syntax to render mdx v3

### DIFF
--- a/modules/client/examples/05-encoders-decoders/06-withdraw.ts
+++ b/modules/client/examples/05-encoders-decoders/06-withdraw.ts
@@ -117,6 +117,7 @@ console.log({ erc20DecodedParams });
 /* MARKDOWN
 Returns:
 
+```
 { erc20DecodedParams:
   {
     type: "erc20",
@@ -125,7 +126,7 @@ Returns:
     tokenAddress: "0x1234567890123456789012345678901234567890",
   }
 }
-
+```
 */
 
 /* MARKDOWN
@@ -162,6 +163,7 @@ console.log({ erc721DecodedParams });
 
 /* MARKDOWN
 Returns:
+```
 {
   type: TokenType.ERC721;
   tokenAddress: "0x1234567890123456789012345678901234567890";
@@ -169,6 +171,7 @@ Returns:
   daoAddressOrEns: "0x1234567890123456789012345678901234567890";
   recipientAddressOrEns: "0x1234567890123456789012345678901234567890";
 }
+```
 */
 /* MARKDOWN
 ### NFT (ERC-1155) Tokens
@@ -205,6 +208,7 @@ console.log({ erc1155WithdrawDecodedParams });
 
 /* MARKDOWN
 Returns:
+```
 {
   type: TokenType.ERC1155,
   tokenAddress: "0x1234567890123456789012345678901234567890",
@@ -213,4 +217,5 @@ Returns:
   daoAddressOrEns: "0x1234567890123456789012345678901234567890",
   recipientAddressOrEns: "0x1234567890123456789012345678901234567890",
 }
+```
 */


### PR DESCRIPTION
## Description

Fixed syntax of one file in the examples folder. It wasn't using backticks to represent code, so our dev-portal which will now use mdx v3 wasn't rendering it properly.

Task ID: [OS-993](https://aragonassociation.atlassian.net/browse/OS-994)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them when possible.
- [ ] I have updated the `CHANGELOG.md` file in the root folder of the package after the `[UPCOMING]` title and before the latest version.
- [ ] I have tested my code on the test network.


[OS-993]: https://aragonassociation.atlassian.net/browse/OS-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ