### PR TITLE
fix: adapt subgraph queries to new version of subgraph

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -18,6 +18,11 @@ TEMPLATE:
 -->
 
 ## [UPCOMING]
+## [1.23.2]
+
+### Changed
+- Update subgraph queries to version 1.4.2 of subgraph
+
 ## [1.23.1]
 
 ### Fixed

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/src/multisig/internal/graphql-queries/proposal.ts
+++ b/modules/client/src/multisig/internal/graphql-queries/proposal.ts
@@ -29,8 +29,10 @@ query MultisigProposal($proposalId: ID!) {
     executed
     approvalReached
     isSignaling
-    approvers(first: 1000){
-      id
+    approvals(first: 1000){
+      approver{
+        address
+      }
     }
   }
 }
@@ -48,14 +50,16 @@ query MultisigProposals($where: MultisigProposal_filter!, $limit:Int!, $skip: In
     executed
     approvalReached
     isSignaling
-    approvals
+    approvalCount
     startDate
     endDate
     executionDate
     executionBlockNumber
     creationBlockNumber
-    approvers {
-      id
+    approvals(first: 1000){
+      approver{
+        address
+      }
     }
     actions {
       to

--- a/modules/client/src/multisig/internal/types.ts
+++ b/modules/client/src/multisig/internal/types.ts
@@ -4,9 +4,7 @@ export type SubgraphMultisigProposalBase = SubgraphProposalBase & {
   plugin: SubgraphMultisigVotingSettings;
   minApprovals: number;
   approvalReached: boolean;
-  approvers: { id: string, approver: { address: string} }[];
-  // TODO change on subgraph fix
-  // approvers: SubgraphMultisigApproversListItem[];
+  approvals: SubgraphMultisigApproversListItem[];
 };
 
 export type SubgraphMultisigProposalListItem = SubgraphMultisigProposalBase;
@@ -20,7 +18,7 @@ export type SubgraphMultisigProposal = SubgraphMultisigProposalBase & {
 };
 
 export type SubgraphMultisigApproversListItem = {
-  approver: { id: string };
+  approver: { address: string };
 };
 
 export type SubgraphMultisigVotingSettings = {

--- a/modules/client/src/multisig/internal/utils.ts
+++ b/modules/client/src/multisig/internal/utils.ts
@@ -66,7 +66,7 @@ export function toMultisigProposal(
       },
     ),
     status: computeProposalStatus(proposal),
-    approvals: proposal.approvers.map(
+    approvals: proposal.approvals.map(
       (a) => a.approver.address,
     ),
   };
@@ -92,7 +92,7 @@ export function toMultisigProposalListItem(
       title: metadata.title,
       summary: metadata.summary,
     },
-    approvals: proposal.approvers.map(
+    approvals: proposal.approvals.map(
       (a) => a.approver.address,
     ),
     actions: proposal.actions.map(

--- a/modules/client/test/integration/multisig-client/methods.test.ts
+++ b/modules/client/test/integration/multisig-client/methods.test.ts
@@ -613,7 +613,7 @@ describe("Client Multisig", () => {
         executionDate: Math.round(Date.now() / 1000).toString(),
         executionBlockNumber: "50",
         executionTxHash: TEST_TX_HASH,
-        approvers: [{ id: `${ADDRESS_ONE}_${ADDRESS_ONE}`, approver: {address: ADDRESS_ONE} }, { id: `${ADDRESS_TWO}_${ADDRESS_ONE}`, approver: {address: ADDRESS_TWO}}],
+        approvals: [{ approver: {address: ADDRESS_ONE} }, { approver: {address: ADDRESS_TWO}}],
         minApprovals: 5,
         plugin: {
           onlyListed: true,
@@ -675,7 +675,7 @@ describe("Client Multisig", () => {
         parseInt(subgraphProposal.executionBlockNumber),
       );
       expect(proposal.approvals).toMatchObject(
-        subgraphProposal.approvers.map((approver) => approver.approver.address),
+        subgraphProposal.approvals.map((approver) => approver.approver.address),
       );
       expect(proposal.settings.minApprovals).toBe(
         subgraphProposal.plugin.minApprovals,
@@ -737,7 +737,7 @@ describe("Client Multisig", () => {
       mockedClient.request.mockResolvedValueOnce({
         multisigProposals: [{
           ...SUBGRAPH_PROPOSAL_BASE,
-          approvers: [{ id: `${ADDRESS_ONE}_${ADDRESS_ONE}`, approver: { address: ADDRESS_ONE } }, { id: `${ADDRESS_TWO}_${ADDRESS_ONE}`, approver: { address: ADDRESS_TWO } }],
+          approvals: [{ approver: { address: ADDRESS_ONE } }, { approver: { address: ADDRESS_TWO } }],
           plugin: {
             onlyListed: true,
           },


### PR DESCRIPTION
## Description

This PR adapts the graphql queries to the no schema released on the new version `1.4.2` of subgraph

Task ID: [OS-1215](https://aragonassociation.atlassian.net/browse/OS-1215)

## Type of change

<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them when possible.
- [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the `[UPCOMING]` title and before the latest version.
- [x] I have tested my code on the test network.


[OS-1215]: https://aragonassociation.atlassian.net/browse/OS-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ