### PR TITLE
feat: Add includeMetadata optional parameter to getPlugin and getPlugins functions

### DIFF
--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -19,7 +19,7 @@ TEMPLATE:
 
 ## [UPCOMING]
 
-## [1.26.1]
+## [1.26.0]
 
 ### Changed
 - Add `includeMetadata` optional parameter to `getPlugin` and `getPlugins` functions which defaults to `true`.

--- a/modules/client/CHANGELOG.md
+++ b/modules/client/CHANGELOG.md
@@ -19,6 +19,11 @@ TEMPLATE:
 
 ## [UPCOMING]
 
+## [1.26.1]
+
+### Changed
+- Add `includeMetadata` optional parameter to `getPlugin` and `getPlugins` functions which defaults to `true`.
+
 ## [1.25.1]
 
 ### Fixed

--- a/modules/client/package.json
+++ b/modules/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/sdk-client",
   "author": "Aragon Association",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/sdk-client.esm.js",

--- a/modules/client/src/internal/client/methods.ts
+++ b/modules/client/src/internal/client/methods.ts
@@ -966,7 +966,16 @@ export class ClientMethods extends ClientCore implements IClientMethods {
 
   private async getPluginRepo(
     pluginRepo: SubgraphPluginRepo,
+    inlcudeMetadata?: boolean,
   ): Promise<PluginRepo> {
+    if (!inlcudeMetadata) {
+      return toPluginRepo(
+        pluginRepo,
+        EMPTY_RELEASE_METADATA_LINK,
+        EMPTY_BUILD_METADATA_LINK
+      );
+    }
+
     let releaseMetadata: PluginRepoReleaseMetadata;
     // releases are ordered son the index 0 will be the latest
     const releaseIpfsUri = pluginRepo?.releases[0]?.metadata;
@@ -1006,6 +1015,7 @@ export class ClientMethods extends ClientCore implements IClientMethods {
    *     - direction = SortDirection.ASC
    *     - sortBy = PluginSortBy.SUBDOMAIN
    *     - subdomain
+   * @param {boolean} [includeMetadata=true]
    * @return {(Promise<PluginRepo[] | null>)}
    * @memberof ClientMethods
    */
@@ -1015,6 +1025,7 @@ export class ClientMethods extends ClientCore implements IClientMethods {
     direction = SortDirection.ASC,
     sortBy = PluginSortBy.SUBDOMAIN,
     subdomain,
+    includeMetadata = true,
   }: PluginQueryParams = {}): Promise<PluginRepoListItem[]> {
     await PluginQuerySchema.strict().validate({
       limit,
@@ -1046,7 +1057,7 @@ export class ClientMethods extends ClientCore implements IClientMethods {
     return Promise.all(
       pluginRepos.map(
         (pluginRepo: SubgraphPluginRepoListItem) => {
-          return this.getPluginRepo(pluginRepo);
+          return this.getPluginRepo(pluginRepo, includeMetadata);
         },
       ),
     );
@@ -1055,10 +1066,14 @@ export class ClientMethods extends ClientCore implements IClientMethods {
    * Get plugin details given an address, release and build
    *
    * @param {string} pluginAddress
+   * @param {boolean} [includeMetadata=true]
    * @return {Promise<PluginRepo>}
    * @memberof ClientMethods
    */
-  public async getPlugin(pluginAddress: string): Promise<PluginRepo> {
+  public async getPlugin(
+    pluginAddress: string,
+    includeMetadata: boolean = true
+  ): Promise<PluginRepo> {
     await AddressOrEnsSchema.strict().validate(pluginAddress);
     const name = "plugin version";
     const query = QueryPlugin;
@@ -1069,7 +1084,7 @@ export class ClientMethods extends ClientCore implements IClientMethods {
       name,
     });
     // get release metadata
-    return this.getPluginRepo(pluginRepo);
+    return this.getPluginRepo(pluginRepo, includeMetadata);
   }
   /**
    * Returns the protocol version of a contract

--- a/modules/client/src/internal/interfaces.ts
+++ b/modules/client/src/internal/interfaces.ts
@@ -78,9 +78,9 @@ export interface IClientMethods {
   /** Retrieves metadata for many daos */
   getDaos: (params: DaoQueryParams) => Promise<DaoListItem[]>;
   /** retrieves the plugin details given an address, release and build */
-  getPlugin: (pluginAddress: string) => Promise<PluginRepo>;
+  getPlugin: (pluginAddress: string, includeMetadata?: boolean) => Promise<PluginRepo>;
   /** Retrieves the list of plugins available on the PluginRegistry */
-  getPlugins: (params?: PluginQueryParams) => Promise<PluginRepoListItem[]>;
+  getPlugins: (params?: PluginQueryParams, includeMetadata?: boolean) => Promise<PluginRepoListItem[]>;
   /** Prepare uninstallation of a plugin */
   prepareUninstallation: (
     params: PrepareUninstallationParams,

--- a/modules/client/src/types.ts
+++ b/modules/client/src/types.ts
@@ -79,6 +79,7 @@ export enum PluginSortBy {
 export type PluginQueryParams = Pagination & {
   sortBy?: PluginSortBy;
   subdomain?: string;
+  includeMetadata?: boolean;
 };
 
 /* Plugin repos */


### PR DESCRIPTION
## Description

- Add optional `includeMetadata` parameter to `getPlugin` and `getPlugins` functions to avoid fetching plugin metadata when not required.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them when possible.
- [x] I have updated the `CHANGELOG.md` file in the root folder of the package after the `[UPCOMING]` title and before the latest version.
- [x] I have tested my code on the test network.
